### PR TITLE
Fix doctests examples indentation

### DIFF
--- a/lib/bitstyles_phoenix/components/form.ex
+++ b/lib/bitstyles_phoenix/components/form.ex
@@ -120,13 +120,13 @@ defmodule BitstylesPhoenix.Components.Form do
 
   ## Examples
 
-    iex> ui_select(f, :week, 1..2, label: "Week", e2e_classname: "e2e-filters-week-week")
-    ~s(<label for="filters_week">Week</label>
-    <select class="e2e-filters-week-week" id="filters_week" name="filters[week]"><option value="1">1</option><option value="2">2</option></select>)
+      iex> ui_select(f, :week, 1..2, label: "Week", e2e_classname: "e2e-filters-week-week")
+      ~s(<label for="filters_week">Week</label>
+      <select class="e2e-filters-week-week" id="filters_week" name="filters[week]"><option value="1">1</option><option value="2">2</option></select>)
 
-    iex> ui_select(f, :week, 1..2, label: "Week", hidden_label: true)
-    ~s(<label for="filters_week" class="u-sr-only">Week</label>
-    <select id="filters_week" name="filters[week]"><option value="1">1</option><option value="2">2</option></select>)
+      iex> ui_select(f, :week, 1..2, label: "Week", hidden_label: true)
+      ~s(<label for="filters_week" class="u-sr-only">Week</label>
+      <select id="filters_week" name="filters[week]"><option value="1">1</option><option value="2">2</option></select>)
 
   """
   def ui_select(form, field, options, opts \\ []) do

--- a/lib/bitstyles_phoenix/components/icon.ex
+++ b/lib/bitstyles_phoenix/components/icon.ex
@@ -13,17 +13,17 @@ defmodule BitstylesPhoenix.Components.Icon do
 
   ## Examples
 
-    iex> safe_to_string ui_icon("right")
-    ~s(<svg alt="" class="a-icon" role="presentation"><use xlink:href="#icon-right"></svg>)
+      iex> safe_to_string ui_icon("right")
+      ~s(<svg alt="" class="a-icon" role="presentation"><use xlink:href="#icon-right"></svg>)
 
-    iex> safe_to_string ui_icon("right", size: "s")
-    ~s(<svg alt="" class="a-icon a-icon--s" role="presentation"><use xlink:href="#icon-right"></svg>)
+      iex> safe_to_string ui_icon("right", size: "s")
+      ~s(<svg alt="" class="a-icon a-icon--s" role="presentation"><use xlink:href="#icon-right"></svg>)
 
-    iex> safe_to_string ui_icon("trashcan")
-    ~s(<svg alt="" class="a-icon" role="presentation"><use xlink:href="#icon-trashcan"></svg>)
+      iex> safe_to_string ui_icon("trashcan")
+      ~s(<svg alt="" class="a-icon" role="presentation"><use xlink:href="#icon-trashcan"></svg>)
 
-    iex> safe_to_string ui_icon("trashcan", class: "foo bar")
-    ~s(<svg alt="" class="a-icon foo bar" role="presentation"><use xlink:href="#icon-trashcan"></svg>)
+      iex> safe_to_string ui_icon("trashcan", class: "foo bar")
+      ~s(<svg alt="" class="a-icon foo bar" role="presentation"><use xlink:href="#icon-trashcan"></svg>)
   """
   def ui_icon(name, opts \\ []) do
     classname =


### PR DESCRIPTION
Doctests' examples needs 4 spaces indentation to be rendered with the proper styles by `ex_doc`.

<img width="1679" alt="Screen Shot 2021-04-07 at 9 05 20 AM" src="https://user-images.githubusercontent.com/3228071/113825799-b3ea8a80-9781-11eb-9313-945d08d3e2e6.png">

