### PR TITLE
[#12] Update component: Icon

### DIFF
--- a/lib/bitstyles_phoenix.ex
+++ b/lib/bitstyles_phoenix.ex
@@ -41,10 +41,10 @@ defmodule BitstylesPhoenix do
   """)
 
   showcase("Icon size: l", """
-    ui_icon("trashcan", size: 'l')
+    ui_icon("trashcan", size: "l")
   """)
 
   showcase("Icon size: l, width: 40", """
-    ui_icon("trashcan", size: 'l', width: 40)
+    ui_icon("trashcan", size: "l", width: "40", height: "40")
   """)
 end

--- a/lib/bitstyles_phoenix.ex
+++ b/lib/bitstyles_phoenix.ex
@@ -33,4 +33,18 @@ defmodule BitstylesPhoenix do
   showcase("Inline errors", """
     ui_error_tag("Some error")
   """)
+
+  showcase_section("Icons", "Components.Icon.ui_icon/2")
+
+  showcase("Icon", """
+    ui_icon("trashcan")
+  """)
+
+  showcase("Icon size: l", """
+    ui_icon("trashcan", size: 'l')
+  """)
+
+  showcase("Icon size: l, width: 40", """
+    ui_icon("trashcan", size: 'l', width: 40)
+  """)
 end

--- a/lib/bitstyles_phoenix/components/icon.ex
+++ b/lib/bitstyles_phoenix/components/icon.ex
@@ -11,26 +11,40 @@ defmodule BitstylesPhoenix.Components.Icon do
 
   `opts[:name]` — The name of the icon to render. This must be present in the SVG that renders all the icons in the top of the body e.g. `_svgs.html.eex` as a `<symbol>` containing one filled path.
 
+  `opts[:size]` - Specify the icon size to use. Available sizes are specified in CSS, and default to `s`, `m`, `l`, `xl`. If you do not specify a size, the icon will fit into a `1em` square.
+
   ## Examples
 
       iex> safe_to_string ui_icon("right")
-      ~s(<svg alt="" class="a-icon" role="presentation"><use xlink:href="#icon-right"></svg>)
+      ~s(<svg aria-hidden="true" class="a-icon" focusable="false" height="16" width="16" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-right"></svg>)
 
       iex> safe_to_string ui_icon("right", size: "s")
-      ~s(<svg alt="" class="a-icon a-icon--s" role="presentation"><use xlink:href="#icon-right"></svg>)
+      ~s(<svg aria-hidden="true" class="a-icon a-icon--s" focusable="false" height="16" width="16" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-right"></svg>)
 
       iex> safe_to_string ui_icon("trashcan")
-      ~s(<svg alt="" class="a-icon" role="presentation"><use xlink:href="#icon-trashcan"></svg>)
+      ~s(<svg aria-hidden="true" class="a-icon" focusable="false" height="16" width="16" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-trashcan"></svg>)
+
+      iex> safe_to_string ui_icon("trashcan", width: 20)
+      ~s(<svg aria-hidden="true" class="a-icon" focusable="false" height="20" width="20" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-trashcan"></svg>)
 
       iex> safe_to_string ui_icon("trashcan", class: "foo bar")
-      ~s(<svg alt="" class="a-icon foo bar" role="presentation"><use xlink:href="#icon-trashcan"></svg>)
+      ~s(<svg aria-hidden="true" class="a-icon foo bar" focusable="false" height="16" width="16" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-trashcan"></svg>)
   """
   def ui_icon(name, opts \\ []) do
     classname =
       classnames(["a-icon", {"a-icon--#{opts[:size]}", opts[:size] != nil}, opts[:class]])
+    opts = opts |> put_default_width()
 
-    content_tag(:svg, class: classname, alt: "", role: "presentation") do
+    content_tag(:svg, class: classname, "aria-hidden": "true", focusable: "false", xmlns: "http://www.w3.org/2000/svg", width: opts[:width], height: opts[:width]) do
       tag(:use, "xlink:href": "#icon-#{name}")
+    end
+  end
+
+  defp put_default_width(opts) do
+    if is_integer(opts[:width]) do
+      opts
+    else
+      opts |> Keyword.put_new(:width, 16)
     end
   end
 end

--- a/lib/bitstyles_phoenix/components/icon.ex
+++ b/lib/bitstyles_phoenix/components/icon.ex
@@ -34,23 +34,26 @@ defmodule BitstylesPhoenix.Components.Icon do
     classname =
       classnames(["a-icon", {"a-icon--#{opts[:size]}", opts[:size] != nil}, opts[:class]])
 
-    opts = opts
-        |> put_defaults()
-        |> Keyword.put(:class, classname)
-        |> Keyword.merge("aria-hidden": "true",
-                                         focusable: "false",
-                                          xmlns: "http://www.w3.org/2000/svg")
+    opts =
+      opts
+      |> put_defaults()
+      |> Keyword.put(:class, classname)
+      |> Keyword.merge(
+        "aria-hidden": "true",
+        focusable: "false",
+        xmlns: "http://www.w3.org/2000/svg"
+      )
+      |> Keyword.drop([:size])
 
     content_tag(:svg, opts) do
       tag(:use, "xlink:href": "#icon-#{name}")
     end
   end
 
- @default_size 16
+  @default_size 16
   defp put_defaults(opts) do
-      opts 
-      |> Keyword.put_new(:width, @default_size)
-      |> Keyword.put_new(:height, @default_size)
-   end
+    opts
+    |> Keyword.put_new(:width, @default_size)
+    |> Keyword.put_new(:height, @default_size)
   end
 end

--- a/lib/bitstyles_phoenix/components/icon.ex
+++ b/lib/bitstyles_phoenix/components/icon.ex
@@ -24,7 +24,7 @@ defmodule BitstylesPhoenix.Components.Icon do
       iex> safe_to_string ui_icon("trashcan")
       ~s(<svg aria-hidden="true" class="a-icon" focusable="false" height="16" width="16" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-trashcan"></svg>)
 
-      iex> safe_to_string ui_icon("trashcan", width: 20)
+      iex> safe_to_string ui_icon("trashcan", width: "20", height: "20")
       ~s(<svg aria-hidden="true" class="a-icon" focusable="false" height="20" width="20" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-trashcan"></svg>)
 
       iex> safe_to_string ui_icon("trashcan", class: "foo bar")

--- a/lib/bitstyles_phoenix/components/icon.ex
+++ b/lib/bitstyles_phoenix/components/icon.ex
@@ -33,9 +33,17 @@ defmodule BitstylesPhoenix.Components.Icon do
   def ui_icon(name, opts \\ []) do
     classname =
       classnames(["a-icon", {"a-icon--#{opts[:size]}", opts[:size] != nil}, opts[:class]])
+
     opts = opts |> put_default_width()
 
-    content_tag(:svg, class: classname, "aria-hidden": "true", focusable: "false", xmlns: "http://www.w3.org/2000/svg", width: opts[:width], height: opts[:width]) do
+    content_tag(:svg,
+      class: classname,
+      "aria-hidden": "true",
+      focusable: "false",
+      xmlns: "http://www.w3.org/2000/svg",
+      width: opts[:width],
+      height: opts[:width]
+    ) do
       tag(:use, "xlink:href": "#icon-#{name}")
     end
   end

--- a/lib/bitstyles_phoenix/components/icon.ex
+++ b/lib/bitstyles_phoenix/components/icon.ex
@@ -34,25 +34,23 @@ defmodule BitstylesPhoenix.Components.Icon do
     classname =
       classnames(["a-icon", {"a-icon--#{opts[:size]}", opts[:size] != nil}, opts[:class]])
 
-    opts = opts |> put_default_width()
+    opts = opts
+        |> put_defaults()
+        |> Keyword.put(:class, classname)
+        |> Keyword.merge("aria-hidden": "true",
+                                         focusable: "false",
+                                          xmlns: "http://www.w3.org/2000/svg")
 
-    content_tag(:svg,
-      class: classname,
-      "aria-hidden": "true",
-      focusable: "false",
-      xmlns: "http://www.w3.org/2000/svg",
-      width: opts[:width],
-      height: opts[:width]
-    ) do
+    content_tag(:svg, opts) do
       tag(:use, "xlink:href": "#icon-#{name}")
     end
   end
 
-  defp put_default_width(opts) do
-    if is_integer(opts[:width]) do
-      opts
-    else
-      opts |> Keyword.put_new(:width, 16)
-    end
+ @default_size 16
+  defp put_defaults(opts) do
+      opts 
+      |> Keyword.put_new(:width, @default_size)
+      |> Keyword.put_new(:height, @default_size)
+   end
   end
 end


### PR DESCRIPTION
Closes #12 

- Updates SVG icons to current bitstyles expected markup (focusable=false, aria-hidden=true etc)
- Allows user to specify a pixel width & height, defaults to 16 to match the default icon size of 1em

Adds icon examples to the showcase file, which doesn’t yet render anything visible as the icon file is not available. The DOM is already correct though