### PR TITLE
[#11] Add component: flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CircleCI](https://circleci.com/gh/bitcrowd/bitstyles_phoenix.svg?style=shield)](https://circleci.com/gh/bitcrowd/bitstyles_phoenix)
 
 Basic helpers for [bitstyles](https://github.com/bitcrowd/bitstyles) for elixir phoenix projects.
-Currently made for version 1.0.2 of bitstyles. Future versions might still work, since
+Currently made for version 1.0.6 of bitstyles. Future versions might still work, since
 the common interface is just CSS classes. Feel free to drop PRs if you notice any inconsistencies with new versions.
 
 ## Requirements

--- a/lib/bitstyles_phoenix.ex
+++ b/lib/bitstyles_phoenix.ex
@@ -33,4 +33,22 @@ defmodule BitstylesPhoenix do
   showcase("Inline errors", """
     ui_error_tag("Some error")
   """)
+
+  showcase_section("Flash", "Components.Flash.ui_flash/2")
+
+  showcase("Brand-1", """
+    ui_flash("Something you may be interested to hear", variant: "brand-1")
+  """)
+
+  showcase("Positive", """
+    ui_flash("Changes succesfully saved", variant: "positive")
+  """)
+
+  showcase("Warning", """
+    ui_flash("Login not successful, please try that again", variant: "warning")
+  """)
+
+  showcase("Danger", """
+    ui_flash("An error occured, please contact an admin", variant: "danger")
+  """)
 end

--- a/lib/bitstyles_phoenix.ex
+++ b/lib/bitstyles_phoenix.ex
@@ -13,42 +13,48 @@ defmodule BitstylesPhoenix do
   showcase_section("Buttons", "Components.Button.ui_button/2")
 
   showcase("Default", """
-    ui_button("Button", type: "submit")
+  ui_button("Button", type: "submit")
   """)
 
   showcase("UI", """
-    ui_button("Button", variant: :ui)
+  ui_button("Button", variant: :ui)
   """)
 
   showcase("Danger", """
-    ui_button("Button", variant: :danger)
+  ui_button("Button", variant: :danger)
   """)
 
   showcase("UI Danger", """
-    ui_button("Button", variant: [:ui, :danger])
+  ui_button("Button", variant: [:ui, :danger])
   """)
 
   showcase_section("Errors", "Components.Error.ui_error_tag/1")
 
   showcase("Inline errors", """
-    ui_error_tag("Some error")
+  ui_error_tag("Some error")
   """)
 
   showcase_section("Flash", "Components.Flash.ui_flash/2")
 
   showcase("Brand-1", """
-    ui_flash("Something you may be interested to hear", variant: "brand-1")
+  ui_flash("Something you may be interested to hear", variant: "brand-1")
   """)
 
   showcase("Positive", """
-    ui_flash("Changes succesfully saved", variant: "positive")
+  ui_flash("Changes succesfully saved", variant: "positive")
   """)
 
   showcase("Warning", """
-    ui_flash("Login not successful, please try that again", variant: "warning")
+  ui_flash("Login not successful, please try that again", variant: "warning")
   """)
 
   showcase("Danger", """
-    ui_flash("An error occured, please contact an admin", variant: "danger")
+  ui_flash("An error occured, please contact an admin", variant: "danger")
+  """)
+
+  showcase("Danger", """
+  ui_flash(variant: "danger") do
+    "An error occured, please contact an admin"
+  end
   """)
 end

--- a/lib/bitstyles_phoenix/components.ex
+++ b/lib/bitstyles_phoenix/components.ex
@@ -2,10 +2,11 @@ defmodule BitstylesPhoenix.Components do
   defmacro __using__(_) do
     quote do
       import BitstylesPhoenix.Components.Button
-      import BitstylesPhoenix.Components.Time
+      import BitstylesPhoenix.Components.Error
+      import BitstylesPhoenix.Components.Flash
       import BitstylesPhoenix.Components.Form
       import BitstylesPhoenix.Components.Icon
-      import BitstylesPhoenix.Components.Error
+      import BitstylesPhoenix.Components.Time
     end
   end
 end

--- a/lib/bitstyles_phoenix/components/flash.ex
+++ b/lib/bitstyles_phoenix/components/flash.ex
@@ -27,6 +27,11 @@ defmodule BitstylesPhoenix.Components.Flash do
       iex> safe_to_string ui_flash("Saved successfully", variant: "danger")
       ~s(<div aria-live="polite" class="u-padding-l--y a-flash a-flash--danger"><div class="a-content u-flex u-items-center u-font--medium">Saved successfully</div></div>)
 
+      iex> safe_to_string(ui_flash(variant: "danger") do
+      ...>   "Saved successfully"
+      ...> end)
+      ~s(<div aria-live="polite" class="u-padding-l--y a-flash a-flash--danger"><div class="a-content u-flex u-items-center u-font--medium">Saved successfully</div></div>)
+
   """
   def ui_flash(opts, do: contents) do
     ui_flash(contents, opts)

--- a/lib/bitstyles_phoenix/components/flash.ex
+++ b/lib/bitstyles_phoenix/components/flash.ex
@@ -37,7 +37,7 @@ defmodule BitstylesPhoenix.Components.Flash do
       classnames(["u-padding-l--y a-flash", {"a-flash--#{opts[:variant]}", opts[:variant] != nil}])
 
     content_tag(:div, class: classname, "aria-live": "polite") do
-      content_tag(:div, contents,  class: "a-content u-flex u-items-center u-font--medium")
+      content_tag(:div, contents, class: "a-content u-flex u-items-center u-font--medium")
     end
   end
 end

--- a/lib/bitstyles_phoenix/components/flash.ex
+++ b/lib/bitstyles_phoenix/components/flash.ex
@@ -9,17 +9,23 @@ defmodule BitstylesPhoenix.Components.Flash do
   @doc ~s"""
   Inform the user of a global or important event, such as may happen after a page reload. There are several variants, which use color, iconography, and html attributes to indicate severity.
 
-  `opts[:variant]` — specifies which visual variant of flash you want, from those available in the CSS classes e.g. `brand-1`, `warning`, `info`, `danger`
+  See [https://bitcrowd.github.io/bitstyles/?path=/docs/ui-flashes--flash-brand-1](https://bitcrowd.github.io/bitstyles/?path=/docs/ui-flashes--flash-brand-1)
 
-  `opts[:icon]` - optional. You can specify the icon that is rendered by name. The icon must be present in the icon svg
+  `opts[:variant]` — specifies which visual variant of flash you want, from those available in CSS. Defaults include: `brand-1`, `warning`, `info`, `danger`
 
   ## Examples
 
       iex> safe_to_string ui_flash("Saved successfully", variant: "positive")
-      ~s(<div class="a-flash a-flash--positive">Save</div>)
+      ~s(<div aria-live="polite" class="u-padding-l--y a-flash a-flash--positive"><div class="a-content u-flex u-items-center u-font--medium">Saved successfully</div></div>)
 
-      iex> safe_to_string ui_flash("Saved successfully", variant: "positive", icon: "check")
-      ~s(<div class="a-flash a-flash--positive">Save</div>)
+      iex> safe_to_string ui_flash("Saved successfully", variant: "brand-1", icon: "check")
+      ~s(<div aria-live="polite" class="u-padding-l--y a-flash a-flash--brand-1"><div class="a-content u-flex u-items-center u-font--medium">Saved successfully</div></div>)
+
+      iex> safe_to_string ui_flash("Saved successfully", variant: "warning")
+      ~s(<div aria-live="polite" class="u-padding-l--y a-flash a-flash--warning"><div class="a-content u-flex u-items-center u-font--medium">Saved successfully</div></div>)
+
+      iex> safe_to_string ui_flash("Saved successfully", variant: "danger")
+      ~s(<div aria-live="polite" class="u-padding-l--y a-flash a-flash--danger"><div class="a-content u-flex u-items-center u-font--medium">Saved successfully</div></div>)
 
   """
   def ui_flash(opts, do: contents) do
@@ -28,7 +34,10 @@ defmodule BitstylesPhoenix.Components.Flash do
 
   def ui_flash(contents, opts) do
     classname =
-      classnames(["a-flash", {"a-flash--#{opts[:variant]}", opts[:variant] != nil}])
-    content_tag(:div, contents, class: classname)
+      classnames(["u-padding-l--y a-flash", {"a-flash--#{opts[:variant]}", opts[:variant] != nil}])
+
+    content_tag(:div, class: classname, "aria-live": "polite") do
+      content_tag(:div, contents,  class: "a-content u-flex u-items-center u-font--medium")
+    end
   end
 end

--- a/lib/bitstyles_phoenix/components/flash.ex
+++ b/lib/bitstyles_phoenix/components/flash.ex
@@ -1,0 +1,34 @@
+defmodule BitstylesPhoenix.Components.Flash do
+  import Phoenix.HTML.Tag, only: [content_tag: 3]
+  import BitstylesPhoenix.Classnames
+
+  @moduledoc """
+  Conveniences for building flash messages.
+  """
+
+  @doc ~s"""
+  Inform the user of a global or important event, such as may happen after a page reload. There are several variants, which use color, iconography, and html attributes to indicate severity.
+
+  `opts[:variant]` — specifies which visual variant of flash you want, from those available in the CSS classes e.g. `brand-1`, `warning`, `info`, `danger`
+
+  `opts[:icon]` - optional. You can specify the icon that is rendered by name. The icon must be present in the icon svg
+
+  ## Examples
+
+      iex> safe_to_string ui_flash("Saved successfully", variant: "positive")
+      ~s(<div class="a-flash a-flash--positive">Save</div>)
+
+      iex> safe_to_string ui_flash("Saved successfully", variant: "positive", icon: "check")
+      ~s(<div class="a-flash a-flash--positive">Save</div>)
+
+  """
+  def ui_flash(opts, do: contents) do
+    ui_flash(contents, opts)
+  end
+
+  def ui_flash(contents, opts) do
+    classname =
+      classnames(["a-flash", {"a-flash--#{opts[:variant]}", opts[:variant] != nil}])
+    content_tag(:div, contents, class: classname)
+  end
+end

--- a/lib/bitstyles_phoenix/showcase.ex
+++ b/lib/bitstyles_phoenix/showcase.ex
@@ -25,9 +25,9 @@ defmodule BitstylesPhoenix.Showcase do
   defmacro showcase(name, code) do
     docs = """
     ### #{name}
-
-        #{String.trim(code)}
-
+    ```
+    #{code}
+    ```
     #{sandbox(code)}
 
     """

--- a/test/bitstyles_phoenix/component_test.exs
+++ b/test/bitstyles_phoenix/component_test.exs
@@ -4,7 +4,9 @@ defmodule BitstylesPhoenix.ComponentTest do
   use BitstylesPhoenix.Components
 
   doctest BitstylesPhoenix.Components.Button
+  doctest BitstylesPhoenix.Components.Error
+  doctest BitstylesPhoenix.Components.Flash
   doctest BitstylesPhoenix.Components.Icon
   doctest BitstylesPhoenix.Components.Time
-  doctest BitstylesPhoenix.Components.Error
+
 end

--- a/test/bitstyles_phoenix/component_test.exs
+++ b/test/bitstyles_phoenix/component_test.exs
@@ -8,5 +8,4 @@ defmodule BitstylesPhoenix.ComponentTest do
   doctest BitstylesPhoenix.Components.Flash
   doctest BitstylesPhoenix.Components.Icon
   doctest BitstylesPhoenix.Components.Time
-
 end


### PR DESCRIPTION
Fixes #11 

- Adds a flash component
- Drive-by update to the README, correcting the version number of bitstyles that we currently import

TODO:
- [] Add icons

Looks like:
<img width="752" alt="Screenshot 2021-04-13 at 11 04 50" src="https://user-images.githubusercontent.com/2479422/114527275-13e0a580-9c48-11eb-9af6-59662155dba2.png">
