### PR TITLE
[#3] Link to docs

### DIFF
--- a/lib/bitstyles_phoenix/components/button.ex
+++ b/lib/bitstyles_phoenix/components/button.ex
@@ -14,6 +14,8 @@ defmodule BitstylesPhoenix.Components.Button do
 
   All other parameters you pass are forwarded to the Phoenix link or submit helpers, if one of those is rendered.
 
+  See the [bitstyles button docs](https://bitcrowd.github.io/bitstyles/?path=/docs/ui-buttons-buttons--page) for available button variants.
+
   ## Examples
 
       iex> safe_to_string ui_button("Save", type: "submit")

--- a/lib/bitstyles_phoenix/components/error.ex
+++ b/lib/bitstyles_phoenix/components/error.ex
@@ -23,6 +23,8 @@ defmodule BitstylesPhoenix.Components.Error do
 
   When errors are given in tuples {error, error_opts} they are given to the `translate_errors` callback.
 
+  The error will be rendered with the warning color, as specified in [bitstyles colors](https://bitcrowd.github.io/bitstyles/?path=/docs/utilities-fg--warning).
+
   ## Examples
 
       iex> safe_to_string ui_error_tag("Foo error")

--- a/lib/bitstyles_phoenix/components/form.ex
+++ b/lib/bitstyles_phoenix/components/form.ex
@@ -46,6 +46,10 @@ defmodule BitstylesPhoenix.Components.Form do
   `opts[:label]` — Override the default text to be used in the `<label>`
   `opts[:hidden_label]` — The label element will be visually hidden, but still present in the DOM
 
+  See the [bitstyles form docs](https://bitcrowd.github.io/bitstyles/?path=/docs/base-forms--fieldset) for examples of inputs, selects, textareas, labels etc. in use.
+
+  See the [bitstyles form docs](https://bitcrowd.github.io/bitstyles/?path=/docs/ui-data-forms--login-form) for examples of form layouts.
+
   ## Examples
 
       iex> ui_input(f, :field)
@@ -88,6 +92,8 @@ defmodule BitstylesPhoenix.Components.Form do
   `opts[:e2e_classname]` — A classname that will be applied to the input for testing purposes, only on integration env
   `opts[:label]` — Override the default text to be used in the `<label>`
 
+  See the [bitstyles textarea docs](https://bitcrowd.github.io/bitstyles/?path=/docs/base-forms--textarea-and-label) for examples of textareas and labels in use.
+
   ## Examples
 
       iex> ui_textarea(f, :address)
@@ -117,6 +123,8 @@ defmodule BitstylesPhoenix.Components.Form do
   `options` — the options to be rendered in this select element
   `opts[:e2e_classname]` — A classname that will be applied to the input for testing purposes, only on integration env
   `opts[:label]` — Override the default text to be used in the `<label>`
+
+  See the [bitstyles select docs](https://bitcrowd.github.io/bitstyles/?path=/docs/base-forms--select-and-label) for examples of textareas and labels in use.
 
   ## Examples
 

--- a/lib/bitstyles_phoenix/components/icon.ex
+++ b/lib/bitstyles_phoenix/components/icon.ex
@@ -13,6 +13,8 @@ defmodule BitstylesPhoenix.Components.Icon do
 
   `opts[:size]` - Specify the icon size to use. Available sizes are specified in CSS, and default to `s`, `m`, `l`, `xl`. If you do not specify a size, the icon will fit into a `1em` square.
 
+  See the [bitstyles icon docs](https://bitcrowd.github.io/bitstyles/?path=/docs/atoms-icon--icon) for examples of icon usage, and available icons in the bitstyles icon set.
+
   ## Examples
 
       iex> safe_to_string ui_icon("right")


### PR DESCRIPTION
Fixes #3 

Adds links to the bitstyles storybook docs hosted on github pages, to each of the components here that has an entry there.

Looks like:

<img width="752" alt="Screenshot 2021-04-13 at 11 59 58" src="https://user-images.githubusercontent.com/2479422/114534978-d7b14300-9c4f-11eb-836e-e472ed14d420.png">
