### PR TITLE
Doctest forms & introduce label_opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+* Better documentation for form helpers
+
+### Breaking/Bugfix
+* Do not forward options from form helpers to each `label` anymore, but instead pass options through `label_opts`.
+* Drop `hidden` and `reset` input types for `ui_input`.
+
 ## v0.4.0
 
 ### Added 

--- a/lib/bitstyles_phoenix/components/form.ex
+++ b/lib/bitstyles_phoenix/components/form.ex
@@ -1,12 +1,21 @@
 defmodule BitstylesPhoenix.Form do
   import BitstylesPhoenix.Classnames
+  import BitstylesPhoenix.Showcase
   alias BitstylesPhoenix.Error
+  import Phoenix.HTML, only: [sigil_E: 2]
   alias Phoenix.HTML.Form, as: PhxForm
 
   @moduledoc """
   Form-related UI components.
   The various form helpers here follow the interface provided by HTML — inputs, selects, and textareas.
 
+  All helpers accept the following options:
+
+  ## Options
+  - `:label` — Override the default text to be used in the `<label>`
+  - `:label_opts` — The options passed to the label element
+  - `:hidden_label` — The label element will be visually hidden, but still present in the DOM
+  - `:e2e_classname` — A classname that will be applied to the input for testing purposes, only on integration env
   """
 
   @input_mapping [
@@ -16,12 +25,10 @@ defmodule BitstylesPhoenix.Form do
     datetime: :datetime_input,
     email: :email_input,
     file: :file_input,
-    hidden: :hidden_input,
     number: :number_input,
     password: :password_input,
     radio: :radio_button,
     range: :range_input,
-    reset: :reset,
     search: :search_input,
     telephone: :telephone_input,
     text: :text_input,
@@ -30,45 +37,60 @@ defmodule BitstylesPhoenix.Form do
     url: :url_input
   ]
 
-  # NOTE: The input elements are not doc-testable due to the impossibility
-  #       to provide a form object as first argument without compromising the
-  #       examples readability.
-
   @doc ~S"""
   Renders all types of `<input>` element, with the associated `<label>`s, and any errors for that field. Defaults to `type="text"`, and `maxlength="255"`.
   As with the various `text_input`, `number_input` helpers in `Phoenix.HTML.Form`, this expects the form & field as first parameters.
-  `opts` will be passed on to the respective underlying Phoenix form helper, with the following additional notes:
 
-  `form` — the form object this input is being rendered inside
-  `field` — the atom for the field you’re rendering
-  `opts[:type]` — the type of the input required, analogous to the input types in the HTML standard
-  `opts[:e2e_classname]` — A classname that will be applied to the input for testing purposes, only on integration env
-  `opts[:label]` — Override the default text to be used in the `<label>`
-  `opts[:hidden_label]` — The label element will be visually hidden, but still present in the DOM
+  ## Options
+  - `:type` — the type of the input (one of `:color`, `:checkbox`, `:date`, `:datetime`, `:email`, `:file`, `:number`, `:password`, `:radio`, `:range`, `:search`, `:telephone`, `:text`, `:textarea`, `:time`, `:url`)
+  - All options from above (see top level module doc).
+  - All other options will be passed to the underlying Phoenix form helper
 
   See the [bitstyles form docs](https://bitcrowd.github.io/bitstyles/?path=/docs/base-forms--fieldset) for examples of inputs, selects, textareas, labels etc. in use.
 
   See the [bitstyles form docs](https://bitcrowd.github.io/bitstyles/?path=/docs/ui-data-forms--login-form) for examples of form layouts.
-
-  ## Examples
-
-      iex> ui_input(f, :field)
-      ~s(<label for="field">Field</label>
-      <input id="field" name="field" type="text">)
-
-      iex> ui_input(f, :email_or_name, type: :search, placeholder: "Email or Name search", autofocus: true)
-      ~s(<label for="email_or_number_or_name">Email or name</label>
-      <input id="email_or_number_or_name" name="email_or_name" placeholder="Email or Name search" type="search" autofocus="">)
-
-      iex> ui_input(f, :file, type: :file, accept: "application/pdf")
-      ~s(<label for="file">File</label>
-      <input accept="application/pdf" id="file" name="user[file]" type="file">)
-
-      iex> ui_input(f, :search_term, type: :search, hidden_label: true)
-      ~s(<label for="search_term" class="u-sr-only">Search</label>
-      <input id="search_term" name="search_term" type="search">)
-
   """
+
+  story("Text field with label", """
+      iex> safe_to_string ui_input(@user_form, :name)
+      ~s(<label for="user_name">Name</label><input id="user_name" maxlength="255" name="user[name]" type="text">)
+  """)
+
+  story("Text field with hidden label", """
+      iex> safe_to_string ui_input(@user_form, :name, hidden_label: true)
+      ~s(<label class="u-sr-only" for="user_name">Name</label><input id="user_name" maxlength="255" name="user[name]" type="text">)
+  """)
+
+  story("Text field with options", """
+      iex> safe_to_string ui_input @user_form, :totp, label: "Authentication code", placeholder: "6-digit code", required: true, value: "", inputmode: "numeric", pattern: "[0-9]*", autocomplete: "one-time-code", maxlength: 6, label_opts: [class: "extra"]
+      ~s(<label class="extra" for="user_totp">Authentication code</label><input autocomplete="one-time-code" id="user_totp" inputmode="numeric" maxlength="6" name="user[totp]" pattern="[0-9]*" placeholder="6-digit code" type="text" value="" required>)
+  """)
+
+  story("Email field with label", """
+      iex> safe_to_string ui_input(@user_form, :email, type: :email)
+      ~s(<label for="user_email">Email</label><input id="user_email" maxlength="255" name="user[email]" type="email">)
+  """)
+
+  story("Search field with placholder", """
+      iex> safe_to_string ui_input(@user_form, :email_or_name, type: :search, placeholder: "Search by email or name", autofocus: true)
+      ~s(<label for="user_email_or_name">Email or name</label><input id="user_email_or_name" name="user[email_or_name]" placeholder="Search by email or name" type="search" autofocus>)
+  """)
+
+  story("File field for pdfs", """
+      iex> safe_to_string ui_input(@file_form, :file, type: :file, accept: "application/pdf")
+      ~s(<label for="user_file">File</label><input accept="application/pdf" id="user_file" name="user[file]" type="file">)
+  """)
+
+  story("Checkbox", """
+      iex> safe_to_string ui_input(@user_form, :accept, type: :checkbox)
+      ~s(<label><input name="user[accept]" type="hidden" value="false"><input id="user_accept" name="user[accept]" type="checkbox" value="true">Accept</label>)
+  """)
+
+  story("Radio", """
+      iex> safe_to_string ui_input(@user_form, :option, type: :radio, value: "one", label: "One")
+      ~s(<label><input id="user_option_one" name="user[option]" type="radio" value="one">One</label>)
+  """)
+
   def ui_input(form, field, opts \\ []) do
     opts =
       opts
@@ -83,69 +105,70 @@ defmodule BitstylesPhoenix.Form do
   end
 
   @doc ~S"""
-  Renders `<textarea>` elements, with the associated `<label>`s, and any errors for that field. As with the various form helpers in `Phoenix.HTML.Form`, this expects the form & field as first parameters.
-  This is an alias for ui_input, as we’re matching the HTML elements, which present a different interface to that presented by the phoenix functions (i.e. in HTML we have <textarea>, not <input type="textarea">)
-  `opts` will be passed on to the respective underlying Phoenix form helper, with the following additional notes:
-
-  `form` — the form object this input is being rendered inside
-  `field` — the atom for the field you’re rendering
-  `opts[:e2e_classname]` — A classname that will be applied to the input for testing purposes, only on integration env
-  `opts[:label]` — Override the default text to be used in the `<label>`
+  Renders `<textarea>` elements, with the associated `<label>`s, and any errors for that field.
+  This is a shortcut for `ui_input/3` with `type: :textarea`, accepting the same options as above.
 
   See the [bitstyles textarea docs](https://bitcrowd.github.io/bitstyles/?path=/docs/base-forms--textarea-and-label) for examples of textareas and labels in use.
-
-  ## Examples
-
-      iex> ui_textarea(f, :address)
-      ~s(<label for="user_address">Address</label>
-      <textarea id="user_address" name="user[address]"></textarea>)
-
-      iex> ui_textarea(f, :stringified_metadata, label: "Metadata", value: "Value here", rows: 10, style: "height: auto;")
-      ~s(<label for="user_stringified_metadata">Metadata</label>
-      <textarea id="user_stringified_metadata" name="user[stringified_metadata]" rows="10" style="height: auto;"></textarea>)
-
-      iex> ui_textarea(f, :address, hidden_label: true)
-      ~s(<label for="user_address" class="u-sr-only">Metadata</label>
-      <textarea id="user_address" name="user[address]"></textarea>)
-
   """
+
+  story("Textarea", """
+      iex> safe_to_string ui_textarea(@user_form, :about_me)
+      ~s(<label for="user_about_me">About me</label><textarea id="user_about_me" name="user[about_me]">
+      </textarea>)
+  """)
+
+  story("Textarea with options", """
+      iex> safe_to_string ui_textarea(@user_form, :metadata, label: "Metadata", value: "Value here", rows: 10, style: "height: auto;", label_opts: [class: "extra"])
+      ~s(<label class="extra" for="user_metadata">Metadata</label><textarea id="user_metadata" name="user[metadata]" rows="10" style="height: auto;">
+      Value here</textarea>)
+  """)
+
+  story("Textarea with hidden label", """
+      iex> safe_to_string ui_textarea(@user_form, :address, hidden_label: true)
+      ~s(<label class="u-sr-only" for="user_address">Address</label><textarea id="user_address" name="user[address]">
+      </textarea>)
+  """)
+
   def ui_textarea(form, field, opts \\ []) do
     opts = opts |> Keyword.put(:type, @input_mapping[:textarea])
     ui_input(form, field, opts)
   end
 
   @doc ~S"""
-  Renders `<select>` elements, with the associated `<label>`s, and any errors for that field. As with the `select` form helper in `Phoenix.HTML.Form`, this expects the form, field, and options as first parameters.
-  `opts` will be passed on to the respective underlying Phoenix form helper, with the following additional notes:
+  Renders `<select>` elements, with the associated `<label>`s, and any errors for that field. Uses the `select` form helper in `Phoenix.HTML.Form`.
 
-  `form` — the form object this input is being rendered inside
-  `field` — the atom for the field you’re rendering
-  `options` — the options to be rendered in this select element
-  `opts[:e2e_classname]` — A classname that will be applied to the input for testing purposes, only on integration env
-  `opts[:label]` — Override the default text to be used in the `<label>`
+  ## Options
+  - All options from above (see top level module doc).
+  - All other options will be passed to the underlying Phoenix form helper
 
   See the [bitstyles select docs](https://bitcrowd.github.io/bitstyles/?path=/docs/base-forms--select-and-label) for examples of textareas and labels in use.
-
-  ## Examples
-
-      iex> ui_select(f, :week, 1..2, label: "Week", e2e_classname: "e2e-filters-week-week")
-      ~s(<label for="filters_week">Week</label>
-      <select class="e2e-filters-week-week" id="filters_week" name="filters[week]"><option value="1">1</option><option value="2">2</option></select>)
-
-      iex> ui_select(f, :week, 1..2, label: "Week", hidden_label: true)
-      ~s(<label for="filters_week" class="u-sr-only">Week</label>
-      <select id="filters_week" name="filters[week]"><option value="1">1</option><option value="2">2</option></select>)
-
   """
+
+  story("Select box", """
+      iex> safe_to_string ui_select(@user_form, :week, 1..2)
+      ~s(<label for="user_week">Week</label><select id="user_week" name="user[week]"><option value="1">1</option><option value="2">2</option></select>)
+  """)
+
+  story("Select box without label", """
+      iex> safe_to_string ui_select(@user_form, :week, 1..2, hidden_label: true)
+      ~s(<label class="u-sr-only" for="user_week">Week</label><select id="user_week" name="user[week]"><option value="1">1</option><option value="2">2</option></select>)
+  """)
+
+  story("Select box with options", """
+      iex> safe_to_string ui_select(@user_form, :preference, [{"Ducks", "ducks"}, {"Cats", "cats"}], label: "What do you like best?", label_opts: [class: "extra"])
+      ~s(<label class=\"extra\" for="user_preference">What do you like best?</label><select id="user_preference" name="user[preference]"><option value="ducks">Ducks</option><option value="cats">Cats</option></select>)
+  """)
+
   def ui_select(form, field, options, opts \\ []) do
     label_text = get_label(opts, field)
     label_opts = get_label_opts(opts)
     input_opts = get_input_opts(opts)
 
-    error = Error.ui_error(form, field)
+    label = PhxForm.label(form, field, label_text, label_opts)
     input = PhxForm.select(form, field, options, input_opts)
+    error = Error.ui_error(form, field)
 
-    [PhxForm.label(form, field, label_text, label_opts), input, error]
+    ~E"<%= label %><%= input %><%= error %>"
   end
 
   defp unwrapped_input(form, field, opts) do
@@ -154,10 +177,11 @@ defmodule BitstylesPhoenix.Form do
     label_opts = get_label_opts(opts)
     input_opts = get_input_opts(opts)
 
-    error = Error.ui_error(form, field)
+    label = PhxForm.label(form, field, label_text, label_opts)
     input = render_input(type, form, field, input_opts)
+    error = Error.ui_error(form, field)
 
-    [PhxForm.label(form, field, label_text, label_opts), input, error]
+    ~E"<%= label %><%= input %><%= error %>"
   end
 
   defp wrapped_input(form, field, opts) do
@@ -168,12 +192,7 @@ defmodule BitstylesPhoenix.Form do
     error = Error.ui_error(form, field)
     input = render_input(type, form, field, input_opts)
 
-    label_tag =
-      PhxForm.label do
-        [input, label_text]
-      end
-
-    [label_tag, error]
+    ~E"<%= PhxForm.label do %><%= input %><%= label_text %><% end %><%= error %>"
   end
 
   defp render_input(:radio_button, form, field, opts) do
@@ -191,12 +210,12 @@ defmodule BitstylesPhoenix.Form do
   end
 
   defp get_label_opts(opts) do
+    label_opts = Keyword.get(opts, :label_opts, [])
+
     case opts[:hidden_label] do
-      true -> opts |> Keyword.put(:class, classnames(["u-sr-only"]))
-      false -> opts
-      nil -> opts
+      true -> label_opts |> Keyword.put(:class, classnames(["u-sr-only"]))
+      _ -> label_opts
     end
-    |> Keyword.delete(:hidden_label)
   end
 
   defp get_input_opts(opts) do
@@ -204,7 +223,7 @@ defmodule BitstylesPhoenix.Form do
       "" -> opts
       cls -> opts |> Keyword.put(:class, cls)
     end
-    |> Keyword.drop([:type, :label, :e2e_classname, :hidden_label])
+    |> Keyword.drop([:type, :label, :e2e_classname, :hidden_label, :label_opts])
   end
 
   defp put_type(opts) do

--- a/lib/bitstyles_phoenix/showcase.ex
+++ b/lib/bitstyles_phoenix/showcase.ex
@@ -54,11 +54,13 @@ defmodule BitstylesPhoenix.Showcase do
           srcdoc:
             ~s(<html style="background-color: transparent;"><head><style>@media (prefers-color-scheme: dark\){body{color: #fff;}}</style><link rel="stylesheet" href="#{
               dist
-            }/build/bitstyles.css"></head><body>#{extra_html |> String.replace("\n", "")}#{result}</body></html>),
+            }/build/bitstyles.css"></head><body>#{
+              Enum.join([extra_html, result]) |> String.replace("\n", "")
+            }</body></html>),
           # https://stackoverflow.com/questions/819416/adjust-width-and-height-of-iframe-to-fit-with-content-in-it
           onload:
             "javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+\"px\";}(this));",
-          style: "height:1px;width:100%;border:none;overflow:hidden",
+          style: "height:1px;width:100%;border:none;overflow:hidden;margin-left: 1em",
           allowtransparency: "true"
         )
       )

--- a/test/bitstyles_phoenix/components/form_test.exs
+++ b/test/bitstyles_phoenix/components/form_test.exs
@@ -1,0 +1,13 @@
+defmodule BitstylesPhoenix.FormTest do
+  use ExUnit.Case
+
+  import BitstylesPhoenix.Form
+
+  import Phoenix.HTML, only: [safe_to_string: 1]
+  import Phoenix.HTML.Form
+
+  @user_form form_for(:user, "/")
+  @file_form form_for(:user, "/", multipart: true)
+
+  doctest BitstylesPhoenix.Form
+end


### PR DESCRIPTION
We haven't tested the form helpers so far, since we haven't found a nice way yet. 

This add doctests for all the form helpers and makes them return proper safe-buffers instead of safe-buffer arrays (which works, but is a bit ugly to test & reason about) 

Also this fixes a weirdness on the way, that we were always forwarding all opts to the `label`s as well (including `maxlength` and so on), so instead we now have an extra option `label_opts`.

Also this restuctures the docs for the form helpers so they are readable.

Below a screenshot from the mix docs (you can check yourself with `mix docs`.

<img width="1025" alt="Screenshot 2021-05-28 at 14 42 05" src="https://user-images.githubusercontent.com/239398/119985527-0ba7b400-bfc3-11eb-9853-d3559956120c.png">

