### PR TITLE
Fix icon reference

### DIFF
--- a/lib/bitstyles_phoenix/components/use_svg.ex
+++ b/lib/bitstyles_phoenix/components/use_svg.ex
@@ -30,8 +30,8 @@ defmodule BitstylesPhoenix.UseSVG do
   story(
     "A referenced SVG (external)",
     """
-        iex> safe_to_string ui_svg("logo", external: "assets/icons.svg")
-        ~s(<svg xmlns="http://www.w3.org/2000/svg"><use xlink:href="assets/icons.svg#logo"></svg>)
+        iex> safe_to_string ui_svg("icon-bin", external: "assets/icons.svg")
+        ~s(<svg xmlns="http://www.w3.org/2000/svg"><use xlink:href="assets/icons.svg#icon-bin"></svg>)
     """,
     background: "white"
   )


### PR DESCRIPTION
Fixed the reference in the docs.

![Screenshot 2021-07-01 at 12 07 01](https://user-images.githubusercontent.com/239398/124106812-e0eac880-da64-11eb-9067-bc370c8e948d.png)
