### PR TITLE
Duplicate components to fix UndefinedFunctionError

### DIFF
--- a/lib/bitstyles_phoenix.ex
+++ b/lib/bitstyles_phoenix.ex
@@ -1,4 +1,15 @@
 defmodule BitstylesPhoenix do
+  @components [
+    BitstylesPhoenix.Badge,
+    BitstylesPhoenix.Button,
+    BitstylesPhoenix.Error,
+    BitstylesPhoenix.Flash,
+    BitstylesPhoenix.Form,
+    BitstylesPhoenix.Icon,
+    BitstylesPhoenix.Time,
+    BitstylesPhoenix.UseSVG
+  ]
+
   @moduledoc """
   Documentation for BitstylesPhoenix.
 
@@ -28,9 +39,12 @@ defmodule BitstylesPhoenix do
   Checkout the components for examples and showcases.
 
   #{
-    BitstylesPhoenix.MixProject.bitstyles_phoenix_components()
+    @components
     |> Enum.map(&"- `#{Module.split(&1) |> Enum.join(".")}`")
     |> Enum.join("\n")
   }
   """
+
+  @doc false
+  def components(), do: @components
 end

--- a/lib/bitstyles_phoenix/components.ex
+++ b/lib/bitstyles_phoenix/components.ex
@@ -4,7 +4,7 @@ defmodule BitstylesPhoenix.Components do
   """
 
   defmacro __using__(_) do
-    for c <- BitstylesPhoenix.MixProject.bitstyles_phoenix_components() do
+    for c <- BitstylesPhoenix.components() do
       quote do
         import unquote(c)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,4 @@ defmodule BitstylesPhoenix.MixProject do
       }
     ]
   end
-
-  def bitstyles_phoenix_components, do: @components
 end


### PR DESCRIPTION
At the moment we get UndefinedFunctionError when using BitstylesPhoenix.Components.

```
(UndefinedFunctionError) function BitstylesPhoenix.MixProject.bitstyles_phoenix_components/0 is undefined (module BitstylesPhoenix.MixProject is not available)
    BitstylesPhoenix.MixProject.bitstyles_phoenix_components()
    (bitstyles_phoenix 0.5.0) expanding macro: BitstylesPhoenix.Components.__using__/1
```