### PR TITLE
Refactor assigns from single slot & use button helper

### DIFF
--- a/lib/bitstyles_phoenix/alpine3/dropdown.ex
+++ b/lib/bitstyles_phoenix/alpine3/dropdown.ex
@@ -33,7 +33,7 @@ defmodule BitstylesPhoenix.Alpine3.Dropdown do
         """
         <div style="min-height: 200px">
           <div class="u-relative" x-data="{ dropdownOpen: false }">
-            <button type="button" class="a-button a-button--ui u-h6" @click="dropdownOpen = true">
+            <button @click="dropdownOpen = true" class="a-button a-button--ui" type="button">
               <span class="a-button__label">
                 Select me
               </span>
@@ -88,7 +88,7 @@ defmodule BitstylesPhoenix.Alpine3.Dropdown do
         """
         <div style="min-height: 200px">
           <div class="u-relative" x-data="{ myOwnDropDown: false }">
-            <button type="button" class="a-button a-button--ui u-h6" @click="myOwnDropDown = true">
+            <button @click="myOwnDropDown = true" class="a-button a-button--ui" type="button">
               <span class="a-button__label">
                 Select me
               </span>
@@ -119,19 +119,17 @@ defmodule BitstylesPhoenix.Alpine3.Dropdown do
   )
 
   def ui_js_dropdown(assigns) do
-    button_assigns = assigns_from_single_slot(assigns, :button, with: :button_extra)
+    {_button, button_extra} = assigns_from_single_slot(assigns, :button)
 
-    menu_assigns =
-      assigns_from_single_slot(assigns, :menu, with: :menu_extra, default: [menu_extra: %{}])
+    {_menu, menu_extra} =
+      assigns_from_single_slot(assigns, :menu, with: :menu_extra, optional: true)
 
     extra = assigns_to_attributes(assigns, [:menu, :button, :x_name])
 
     assigns =
       assigns
-      |> assign(extra: extra)
+      |> assign(extra: extra, button_extra: button_extra, menu_extra: menu_extra)
       |> assign_new(:x_name, fn -> "dropdownOpen" end)
-      |> assign(button_assigns)
-      |> assign(menu_assigns)
 
     ~H"""
     <RawDropdown.ui_dropdown x-data={"{ #{@x_name}: false }"} {@extra}>

--- a/lib/bitstyles_phoenix/component.ex
+++ b/lib/bitstyles_phoenix/component.ex
@@ -17,25 +17,16 @@ defmodule BitstylesPhoenix.Component do
           {:exclude, [atom()]} | {:default, fun() | term()} | {:with, fun() | atom()}
   @spec assigns_from_single_slot(assigns :: map(), slot_name :: atom(), [
           assigns_from_single_slot_option
-        ]) :: map()
+        ]) :: keyword()
   def assigns_from_single_slot(assigns, slot_name, opts \\ []) do
     case assigns[slot_name] do
       [slot] ->
         extra = assigns_to_attributes(slot, Keyword.get(opts, :exclude, []))
-
-        opts
-        |> Keyword.fetch!(:with)
-        |> case do
-          value when is_atom(value) -> [{value, extra}]
-          with_fn when is_function(with_fn, 2) -> with_fn.(slot, extra)
-        end
+        {slot, extra}
 
       nil ->
-        if Keyword.has_key?(opts, :default) do
-          case Keyword.get(opts, :default) do
-            value when is_function(value) -> value.()
-            value -> value
-          end
+        if Keyword.has_key?(opts, :optional) do
+          {nil, []}
         else
           raise "please specify #{slot_name} slot"
         end

--- a/lib/bitstyles_phoenix/component/dropdown.ex
+++ b/lib/bitstyles_phoenix/component/dropdown.ex
@@ -2,6 +2,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
   use BitstylesPhoenix.Component
 
   import BitstylesPhoenix.Component.Icon
+  import BitstylesPhoenix.Helper.Button
 
   @moduledoc """
   The dropdown component without any JS.
@@ -67,7 +68,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
         ...> """
         """
         <div class="u-relative">
-          <button type="button" class="a-button a-button--ui u-h6">
+          <button class="a-button a-button--ui" type="button">
             <span class="a-button__label">
               Select me
             </span>
@@ -124,7 +125,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
           <div class="u-flex-grow-1">
           </div>
           <div class="u-relative">
-            <button type="button" class="a-button a-button--ui u-h6">
+            <button class="a-button a-button--ui" type="button">
               <span class="a-button__label">
                 Select me
               </span>
@@ -176,7 +177,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
         ...> """
         """
         <div class="u-relative u-flex u-justify-end">
-          <button type="button" class="a-button a-button--ui u-h6">
+          <button class="a-button a-button--ui" type="button">
             <span class="a-button__label">
               Select me
             </span>
@@ -200,6 +201,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
         </div>
         """
     ''',
+    width: "100%",
     extra_html: """
     <svg xmlns="http://www.w3.org/2000/svg" hidden aria-hidden="true">
       <symbol id="icon-caret-down" viewBox="0 0 100 100">
@@ -233,7 +235,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
           <div class="u-flex-grow-1">
           </div>
           <div class="u-relative u-flex u-justify-end">
-            <button type="button" class="a-button a-button--ui u-h6">
+            <button class="a-button a-button--ui" type="button">
               <span class="a-button__label">
                 Select me
               </span>
@@ -258,6 +260,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
         </div>
         """
     ''',
+    width: "100%",
     extra_html: """
     <svg xmlns="http://www.w3.org/2000/svg" hidden aria-hidden="true">
       <symbol id="icon-caret-down" viewBox="0 0 100 100">
@@ -284,7 +287,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
         ...> """
         """
         <div class="u-relative">
-          <button type="button" class="a-button a-button--ui u-h6 foo">
+          <button class="a-button a-button--ui foo" type="button">
             Custom button content
           </button>
           <ul class="a-dropdown u-overflow--y a-list-reset u-margin-s-top">
@@ -329,7 +332,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
         """
         <div style="min-height: 200px; width: 500px;">
           <div class="u-relative">
-            <button type="button" class="a-button a-button--ui u-h6" aria-controls="dropdown-1" onclick=\"toggle(&#39;dropdown-1&#39;)\">
+            <button aria-controls="dropdown-1" class="a-button a-button--ui" onclick=\"toggle(&#39;dropdown-1&#39;)\" type="button">
               <span class="a-button__label">
                 Select me
               </span>
@@ -376,26 +379,20 @@ defmodule BitstylesPhoenix.Component.Dropdown do
   )
 
   def ui_dropdown(assigns) do
-    button_assigns =
-      assigns_from_single_slot(assigns, :button,
-        exclude: [:class, :label],
-        with: fn button, extra ->
-          [
-            button_extra: extra,
-            button_label: button[:label],
-            button_class: classnames(["a-button a-button--ui u-h6", button[:class]])
-          ]
-        end
-      )
+    {button, button_extra} = assigns_from_single_slot(assigns, :button, exclude: [:label])
 
-    menu_assigns =
-      assigns_from_single_slot(assigns, :menu,
-        exclude: [:class],
-        default: [menu_class: menu_class(assigns[:variant]), menu_extra: %{}],
-        with: fn menu, extra ->
-          [menu_extra: extra, menu_class: menu_class(assigns[:variant], menu[:class])]
-        end
-      )
+    button_assigns = [
+      button_extra: Keyword.put_new(button_extra, :variant, :ui),
+      button_label: button[:label]
+    ]
+
+    {menu, menu_extra} =
+      assigns_from_single_slot(assigns, :menu, exclude: [:class], optional: true)
+
+    menu_assigns = [
+      menu_extra: menu_extra,
+      menu_class: menu_class(assigns[:variant], menu && menu[:class])
+    ]
 
     class =
       classnames([
@@ -407,7 +404,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
     extra =
       assigns_to_attributes(assigns, [:class, :menu, :button, :option, :icon_file, :variant])
 
-    icon_assigns = if file = assigns[:icon_file], do: %{file: file}, else: %{}
+    icon_assigns = if file = assigns[:icon_file], do: [file: file], else: []
 
     assigns =
       assigns
@@ -417,14 +414,14 @@ defmodule BitstylesPhoenix.Component.Dropdown do
 
     ~H"""
       <div class={@class} {@extra}>
-        <button type="button" class={@button_class} {@button_extra}>
+        <%= ui_button(@button_extra) do %>
           <%= if @button_label do %>
             <span class="a-button__label"><%= @button_label %></span>
             <.ui_icon name="caret-down" class="a-button__icon" size="m" {@icon_assigns}/>
           <% else %>
             <%= render_slot(@button) %>
           <% end %>
-        </button>
+        <% end %>
         <ul class={@menu_class} {@menu_extra}>
           <%= for option <- @option do %>
             <li {assigns_to_attributes(option)}>
@@ -437,7 +434,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
   end
 
   @menu_classes ~w(a-dropdown u-overflow--y a-list-reset)
-  defp menu_class(variant, class \\ nil) do
+  defp menu_class(variant, class) do
     classnames(@menu_classes ++ variant_classes(variant) ++ [margin(variant), class])
   end
 

--- a/lib/bitstyles_phoenix/live/dropdown.ex
+++ b/lib/bitstyles_phoenix/live/dropdown.ex
@@ -15,20 +15,19 @@ defmodule BitstylesPhoenix.Live.Dropdown do
   def ui_js_dropdown(assigns) do
     extra = assigns_to_attributes(assigns, [:menu, :button])
 
-    button_assigns = assigns_from_single_slot(assigns, :button, with: :button_extra)
+    {_, button_extra} = assigns_from_single_slot(assigns, :button)
 
-    menu_assigns =
-      assigns_from_single_slot(assigns, :menu,
-        with: fn slot, extra -> get_menu_assigns(slot.id, extra) end,
-        exclude: [:id],
-        default: &get_menu_assigns/0
-      )
+    {_, menu_extra} = assigns_from_single_slot(assigns, :menu, optional: true)
+
+    menu_extra = Keyword.put_new(menu_extra, :id, random_id())
 
     assigns =
-      assigns
-      |> assign(extra: extra)
-      |> assign(button_assigns)
-      |> assign(menu_assigns)
+      assign(assigns,
+        extra: extra,
+        button_extra: button_extra,
+        menu_extra: menu_extra,
+        menu_id: menu_extra[:id]
+      )
 
     ~H"""
     <RawDropdown.ui_dropdown {@extra}>
@@ -42,7 +41,6 @@ defmodule BitstylesPhoenix.Live.Dropdown do
         <%= render_slot(@button) %>
       </:button>
       <:menu
-        id={@menu_id}
         style="display: none"
         phx-click-away={JS.hide(to: "##{@menu_id}",transition: {"is-transitioning", "is-on-screen", "is-off-screen"})}
         {@menu_extra}
@@ -50,10 +48,4 @@ defmodule BitstylesPhoenix.Live.Dropdown do
     </RawDropdown.ui_dropdown>
     """
   end
-
-  defp get_menu_assigns(), do: get_menu_assigns(random_id(), %{})
-
-  defp get_menu_assigns(nil, extra), do: get_menu_assigns(random_id(), extra)
-
-  defp get_menu_assigns(id, extra), do: [menu_id: id, menu_extra: extra]
 end

--- a/test/bitstyles_phoenix/component/dropdown_test.exs
+++ b/test/bitstyles_phoenix/component/dropdown_test.exs
@@ -1,5 +1,5 @@
 defmodule BitstylesPhoenix.Component.DropdownTest do
   use BitstylesPhoenix.ComponentCase, async: true
 
-  doctest BitstylesPhoenix.Component.Dropdown, import: true
+  doctest BitstylesPhoenix.Component.Dropdown
 end


### PR DESCRIPTION
Some refactoring and improvements from yesterday night 🌔  🦉 

- [x] Refactored `assigns_from_single_slot` and remove `with` and `default` to make @maltoe happy
- [x] Use button helper for the dropdown
- [x] Refactor and improve showcases