### PR TITLE
[#86] Migrate to Bitstyles v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Changed
 - `ui_dl_items` now aligns the items to the baseline (following the Bitstyles examples)
+- Updated to bitstyles `v4.3.0`
 
 ## v2.0.0 - 2022-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,27 @@
 # Changelog
 
-## v2.0.0 - 2022-11-12 
+## Unreleased
+### Changed
+- `ui_dl_items` now aligns the items to the baseline (following the Bitstyles examples)
+
+## v2.0.0 - 2022-11-12
 
 Since there is quite some changes in liveview 0.18.0 mainly about link helpers this breaks with the existing API for the `ui_button` and
 `ui_icon_button` components quite a lot. Since the underlying phoenix helper for generating links is now available as component as well,
 the support for the `ui_button` as helper is dropped completely in favor of components.
 
-### Breaking 
+### Breaking
 
 - Updated to LiveView 0.18.X
 - Removed BitstylesPhoenix.Helpers.Button
-  - Removed `ui_button/2` helper 
+  - Removed `ui_button/2` helper
     -> Use the `ui_button` component
   - Removed `ui_icon_button/3` helper
     -> Use the `ui_icon_button` component
-- `ui_button` component now acts as a wrapper for Phoenix.Component.link 
+- `ui_button` component now acts as a wrapper for Phoenix.Component.link
   - Removed `link_fn` on `ui_button` component, since it's main use-case is now deprecated.
 
-### How to update: 
+### How to update:
 
 - Upgrade to LiveView > 0.18
 `<%= ui_button("some label", to: some_path) %>` => `<.ui_button href={some_path}>some label</.ui_button>`
@@ -34,7 +38,7 @@ This version breaks with the existing API quite a lot 🔥, since we changed the
 ### Breaking
 
 All `ui_*` component helpers are now instead [HEEx function components](https://hexdocs.pm/phoenix/views.html#html-components). They will expect the options and arguments
-now through component attributes. The only exception is `ui_button`, which still delegate to the link_helper given via `link_fn`, but is also available as component. 
+now through component attributes. The only exception is `ui_button`, which still delegate to the link_helper given via `link_fn`, but is also available as component.
 In order to migrate to the new components update to Phoenix 1.6.0 and LiveView 1.17.0 and change all templates from
 `*.html.eex` to `*.html.heex` to be able to use the new component syntax. After that you can change your previous `ui_*` helpers to use the new syntax:
 
@@ -44,12 +48,12 @@ If you have contexts, where you do not want to use `heex` templates yet, you can
 
 Below is a list of changes that happened besides the componentization:
 
-- Renamed `ui_error_tag` to `ui_error` 
-- `ui_input` dropped `datetime` input type (was not working anyways) 
-- `ui_input` dropped `radio` input type (use `ui_unwrapped_input` with `radio_button` instead) 
+- Renamed `ui_error_tag` to `ui_error`
+- `ui_input` dropped `datetime` input type (was not working anyways)
+- `ui_input` dropped `radio` input type (use `ui_unwrapped_input` with `radio_button` instead)
 - `ui_input` dropped `textarea` input type (use `ui_textarea` instead)
 - Removed `ui_time/2` without replacement for now
-- Removed `xclassnames/1`. Use `classnames/1` from the same module instead. 
+- Removed `xclassnames/1`. Use `classnames/1` from the same module instead.
 - `classnames/1` now returns `false` instead of empty string when there is no class set.
 - Removed `BitstylesPhoenix.Components` module. Instead of `use BitstylesPhoenix.Components` do `use BitstylesPhoenix`.
 - Removed all `e2e_classname` options. Use `class` instead, which will trim the e2e classes by default (like before).
@@ -76,12 +80,12 @@ Below is a list of changes that happened besides the componentization:
 - Added `icon` option to `ui_button`.
 - Added support for `:datetime` type in `ui_input`, rendered as Browser-native datetime input element
 
-### Changed 
+### Changed
 
 - Added dependency to `phoenix_live_view` >= 1.17.0 (for using `sigil_H/1` and new component syntax)
 - Doctest now use `floki` to prettify the output HTML, so docs will be a nicer read.
 - `classnames/1` is now imported by default with `use BitstylesPhoenix`
-- Updated to bitstyles `v3.0.0` 
+- Updated to bitstyles `v3.0.0`
 - `ui_errors` now uses larger padding
 
 ## v0.8.0

--- a/demo/assets/package-lock.json
+++ b/demo/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "ISC",
       "dependencies": {
         "alpinejs": "^3.5.1",
-        "bitstyles": "^2.0.0"
+        "bitstyles": "^4.0.0"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -24,17 +24,17 @@
       "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA=="
     },
     "node_modules/alpinejs": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.5.1.tgz",
-      "integrity": "sha512-GqdRNYpEW/rCoh45oqbGLQ1w2Uygt8DNEiqD7Di/kklJ+EZ3xjDAlFlgJ2xf37K+NtzEu2NdmkaYY6B9NBI79Q==",
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.10.5.tgz",
+      "integrity": "sha512-qlvnal44Gof2XVfm/lef8fYpXKxR9fjdSki7aFB/9THyFvbsRKZ6lM5SjxXpIs7B0faJt7bgpK2K25gzrraXJw==",
       "dependencies": {
         "@vue/reactivity": "~3.1.1"
       }
     },
     "node_modules/bitstyles": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bitstyles/-/bitstyles-2.0.0.tgz",
-      "integrity": "sha512-BL7C0K2RxWR4F4lKc6Y7aqxWc5aUeKnWqNiWHSnykyCVKgVL2YAGhZxlqwyAtnhkQcDmSSJF8HX69C92TDzsxw=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bitstyles/-/bitstyles-4.3.0.tgz",
+      "integrity": "sha512-Iw6tnPNAvmxZq/zH7WyOb+U5RQ/7JpijDN0iFvqlLMhdHr0L8yVYJfHF36mZBAO1EBLtpG+Zzhj/KDb2bzgQpg=="
     }
   },
   "dependencies": {
@@ -52,17 +52,17 @@
       "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA=="
     },
     "alpinejs": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.5.1.tgz",
-      "integrity": "sha512-GqdRNYpEW/rCoh45oqbGLQ1w2Uygt8DNEiqD7Di/kklJ+EZ3xjDAlFlgJ2xf37K+NtzEu2NdmkaYY6B9NBI79Q==",
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.10.5.tgz",
+      "integrity": "sha512-qlvnal44Gof2XVfm/lef8fYpXKxR9fjdSki7aFB/9THyFvbsRKZ6lM5SjxXpIs7B0faJt7bgpK2K25gzrraXJw==",
       "requires": {
         "@vue/reactivity": "~3.1.1"
       }
     },
     "bitstyles": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bitstyles/-/bitstyles-2.0.0.tgz",
-      "integrity": "sha512-BL7C0K2RxWR4F4lKc6Y7aqxWc5aUeKnWqNiWHSnykyCVKgVL2YAGhZxlqwyAtnhkQcDmSSJF8HX69C92TDzsxw=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bitstyles/-/bitstyles-4.3.0.tgz",
+      "integrity": "sha512-Iw6tnPNAvmxZq/zH7WyOb+U5RQ/7JpijDN0iFvqlLMhdHr0L8yVYJfHF36mZBAO1EBLtpG+Zzhj/KDb2bzgQpg=="
     }
   }
 }

--- a/demo/assets/package.json
+++ b/demo/assets/package.json
@@ -4,6 +4,6 @@
   "license": "ISC",
   "dependencies": {
     "alpinejs": "^3.5.1",
-    "bitstyles": "^2.0.0"
+    "bitstyles": "^4.0.0"
   }
 }

--- a/demo/lib/bitstyles_phoenix_demo_web/live/demo_live.html.heex
+++ b/demo/lib/bitstyles_phoenix_demo_web/live/demo_live.html.heex
@@ -1,5 +1,5 @@
 <article>
-  <header class="u-bg--gray-5 u-padding-l-top u-margin-l-bottom">
+  <header class="u-bg-gray-5 u-padding-l-top u-margin-l-bottom">
     <.ui_content>
       <.ui_page_title>
         Live test

--- a/demo/test/bitstyles_phoenix_demo_web/bitstyles_phoenix_test.exs
+++ b/demo/test/bitstyles_phoenix_demo_web/bitstyles_phoenix_test.exs
@@ -6,11 +6,11 @@ defmodule BitstylesPhoenixWebDemo.BitstylesPhoenixTest do
     session
     |> visit("/")
     |> find(Query.css(".e2e-form", count: 1))
-    |> assert_has(Query.css(".u-fg--warning", text: "can't be blank"))
+    |> assert_has(Query.css(".u-fg-warning", text: "can't be blank"))
 
     session
     |> find(Query.css(".e2e-form-de", count: 1))
-    |> assert_has(Query.css(".u-fg--warning", text: "muss ausgefüllt werden"))
+    |> assert_has(Query.css(".u-fg-warning", text: "muss ausgefüllt werden"))
   end
 
   feature "allows icon config and can still render inline", %{session: session} do

--- a/lib/bitstyles_phoenix.ex
+++ b/lib/bitstyles_phoenix.ex
@@ -22,7 +22,7 @@ defmodule BitstylesPhoenix do
 
   ```elixir
   <.ui_badge>A nice badge</.ui_badge>
-  # => <span class="a-badge u-h6 u-font--medium a-badge--gray">A nice badge</span>
+  # => <span class="a-badge u-h6 u-font-medium a-badge--gray">A nice badge</span>
   ```
 
   ```elixir

--- a/lib/bitstyles_phoenix/alpine3/dropdown.ex
+++ b/lib/bitstyles_phoenix/alpine3/dropdown.ex
@@ -54,7 +54,7 @@ defmodule BitstylesPhoenix.Alpine3.Dropdown do
               </use>
             </svg>
           </button>
-          <ul class="a-dropdown u-overflow--y a-list-reset u-margin-s-top" @click.away="dropdownOpen = false" x-cloak="x-cloak" x-show="dropdownOpen" x-transition:enter="is-transitioning" x-transition:enter-end="is-on-screen" x-transition:enter-start="is-off-screen" x-transition:leave="is-transitioning" x-transition:leave-end="is-off-screen" x-transition:leave-start="is-on-screen">
+          <ul class="a-dropdown u-overflow-y-auto a-list-reset u-margin-s-top" @click.away="dropdownOpen = false" x-cloak="x-cloak" x-show="dropdownOpen" x-transition:enter="is-transitioning" x-transition:enter-end="is-on-screen" x-transition:enter-start="is-off-screen" x-transition:leave="is-transitioning" x-transition:leave-end="is-off-screen" x-transition:leave-start="is-on-screen">
             <li>
               <a href="#" class="a-button a-button--menu u-h6">
                 Option 1
@@ -108,7 +108,7 @@ defmodule BitstylesPhoenix.Alpine3.Dropdown do
               </use>
             </svg>
           </button>
-          <ul class="a-dropdown u-overflow--y a-list-reset u-margin-s-top" @click.away="myOwnDropDown = false" x-cloak="x-cloak" x-show="myOwnDropDown" x-transition:enter="is-transitioning" x-transition:enter-end="is-on-screen" x-transition:enter-start="is-off-screen" x-transition:leave="is-transitioning" x-transition:leave-end="is-off-screen" x-transition:leave-start="is-on-screen">
+          <ul class="a-dropdown u-overflow-y-auto a-list-reset u-margin-s-top" @click.away="myOwnDropDown = false" x-cloak="x-cloak" x-show="myOwnDropDown" x-transition:enter="is-transitioning" x-transition:enter-end="is-on-screen" x-transition:enter-start="is-off-screen" x-transition:leave="is-transitioning" x-transition:leave-end="is-off-screen" x-transition:leave-start="is-on-screen">
             <li>
               <a href="#" class="a-button a-button--menu u-h6">
                 Option 1

--- a/lib/bitstyles_phoenix/alpine3/sidebar.ex
+++ b/lib/bitstyles_phoenix/alpine3/sidebar.ex
@@ -52,14 +52,14 @@ defmodule BitstylesPhoenix.Alpine3.Sidebar do
         <div class="u-flex u-height-100vh" x-data="{ sidebarOpen: false }">
           <header role="banner" class="u-flex">
             <nav class="u-flex">
-              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg--gray-80 u-fg--gray-30">
+              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg-gray-80 u-fg-gray-30">
                 <a href="#" class="u-padding-l">
                   <img src="assets/logo.svg" aria-hidden="true" width="100"/>
                   <span class="u-sr-only">
                     bitcrowd
                   </span>
                 </a>
-                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
                   <li class="u-margin-xs-bottom u-flex">
                     <a href="#" class="a-button a-button--nav u-flex-grow-1">
                       Menu item #1
@@ -72,7 +72,7 @@ defmodule BitstylesPhoenix.Alpine3.Sidebar do
                   </li>
                 </ul>
               </div>
-              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg--gray-80 u-fg--gray-30" @click.away="sidebarOpen = false" id="sidebar-small" x-cloak="x-cloak" x-show="sidebarOpen" x-transition:enter="is-transitioning" x-transition:enter-end="is-on-screen" x-transition:enter-start="is-off-screen" x-transition:leave="is-transitioning" x-transition:leave-end="is-off-screen" x-transition:leave-start="is-on-screen">
+              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg-gray-80 u-fg-gray-30" @click.away="sidebarOpen = false" id="sidebar-small" x-cloak="x-cloak" x-show="sidebarOpen" x-transition:enter="is-transitioning" x-transition:enter-end="is-on-screen" x-transition:enter-start="is-off-screen" x-transition:leave="is-transitioning" x-transition:leave-end="is-off-screen" x-transition:leave-start="is-on-screen">
                 <div class="u-flex">
                   <a href="#" class="u-flex-grow-1 u-padding-l">
                     <img src="assets/logo.svg" aria-hidden="true" width="100"/>
@@ -92,7 +92,7 @@ defmodule BitstylesPhoenix.Alpine3.Sidebar do
                     </button>
                   </div>
                 </div>
-                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
                   <li class="u-margin-xs-bottom u-flex">
                     <a href="#" class="a-button a-button--nav u-flex-grow-1">
                       Menu item #1
@@ -107,7 +107,7 @@ defmodule BitstylesPhoenix.Alpine3.Sidebar do
               </div>
             </nav>
           </header>
-          <main class="u-flex-grow-1 u-overflow--y u-margin-s-top">
+          <main class="u-flex-grow-1 u-overflow-y-auto u-margin-s-top">
             <div class="a-content flex">
               <button type="button" :aria-expanded="sidebarOpen" @click="sidebarOpen = true" aria-controls="sidebar-small" class="a-button a-button--icon u-hidden@l u-margin-s-right" title="Open sidebar">
                 <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon" focusable="false" height="16" width="16">

--- a/lib/bitstyles_phoenix/bitstyles.ex
+++ b/lib/bitstyles_phoenix/bitstyles.ex
@@ -1,7 +1,7 @@
 defmodule BitstylesPhoenix.Bitstyles do
   @moduledoc false
 
-  @default_version "3.0.0"
+  @default_version "3.1.0"
   @cdn_url "https://cdn.jsdelivr.net/npm/bitstyles"
 
   def cdn_url do
@@ -14,7 +14,7 @@ defmodule BitstylesPhoenix.Bitstyles do
   """
   def classname(name), do: classname(name, version())
 
-  def classname(class, version) when version > "3.0.0" do
+  def classname(class, version) when version > "3.0.1" do
     IO.warn("Version #{version} of bitstyles is not yet supported")
     class
   end

--- a/lib/bitstyles_phoenix/bitstyles.ex
+++ b/lib/bitstyles_phoenix/bitstyles.ex
@@ -1,7 +1,7 @@
 defmodule BitstylesPhoenix.Bitstyles do
   @moduledoc false
 
-  @default_version "4.0.0"
+  @default_version "4.2.0"
   @cdn_url "https://cdn.jsdelivr.net/npm/bitstyles"
 
   def cdn_url do
@@ -14,12 +14,22 @@ defmodule BitstylesPhoenix.Bitstyles do
   """
   def classname(name), do: classname(name, version())
 
-  def classname(class, version) when version > "4.0.0" do
+  def classname(class, version) when version > "4.2.0" do
     IO.warn("Version #{version} of bitstyles is not yet supported")
     class
   end
 
-  def classname(class, version) when version == "4.0.0", do: class
+  def classname(class, "4.2.0"), do: class
+
+  def classname(class, version) when version >= "4.0.0" do
+    mapping =
+      case class do
+        "u-border-radius-" <> variant -> "u-round-#{variant}"
+        _ -> class
+      end
+
+    classname(mapping, "4.2.0")
+  end
 
   def classname(class, version) when version >= "2.0.0" do
     mapping =
@@ -31,11 +41,11 @@ defmodule BitstylesPhoenix.Bitstyles do
         "u-font-" <> variant -> "u-font--#{variant}"
         "u-line-height-" <> variant -> "u-line-height--#{variant}"
         "u-text-" <> variant -> "u-text--#{variant}"
-        "u-round-" <> variant -> "u-round--#{variant}"
+        "u-border-radius-" <> variant -> "u-round--#{variant}"
         _ -> class
       end
 
-    classname(mapping, "4.0.0")
+    classname(mapping, "4.1.0")
   end
 
   def classname(class, version) when version >= "1.5.0" do

--- a/lib/bitstyles_phoenix/bitstyles.ex
+++ b/lib/bitstyles_phoenix/bitstyles.ex
@@ -45,7 +45,7 @@ defmodule BitstylesPhoenix.Bitstyles do
         _ -> class
       end
 
-    classname(mapping, "4.1.0")
+    classname(mapping, "4.0.0")
   end
 
   def classname(class, version) when version >= "1.5.0" do

--- a/lib/bitstyles_phoenix/bitstyles.ex
+++ b/lib/bitstyles_phoenix/bitstyles.ex
@@ -32,6 +32,8 @@ defmodule BitstylesPhoenix.Bitstyles do
   end
 
   def classname(class, version) when version >= "2.0.0" do
+    # credo:disable-for-previous-line Credo.Check.Refactor.CyclomaticComplexity
+
     mapping =
       case class do
         "u-overflow-x-auto" -> "u-overflow--x"

--- a/lib/bitstyles_phoenix/bitstyles.ex
+++ b/lib/bitstyles_phoenix/bitstyles.ex
@@ -1,7 +1,7 @@
 defmodule BitstylesPhoenix.Bitstyles do
   @moduledoc false
 
-  @default_version "4.2.0"
+  @default_version "4.3.0"
   @cdn_url "https://cdn.jsdelivr.net/npm/bitstyles"
 
   def cdn_url do
@@ -14,12 +14,12 @@ defmodule BitstylesPhoenix.Bitstyles do
   """
   def classname(name), do: classname(name, version())
 
-  def classname(class, version) when version > "4.2.0" do
+  def classname(class, version) when version > "4.3.0" do
     IO.warn("Version #{version} of bitstyles is not yet supported")
     class
   end
 
-  def classname(class, "4.2.0"), do: class
+  def classname(class, version) when version >= "4.2.0", do: class
 
   def classname(class, version) when version >= "4.0.0" do
     mapping =

--- a/lib/bitstyles_phoenix/bitstyles.ex
+++ b/lib/bitstyles_phoenix/bitstyles.ex
@@ -1,7 +1,7 @@
 defmodule BitstylesPhoenix.Bitstyles do
   @moduledoc false
 
-  @default_version "3.1.0"
+  @default_version "4.0.0"
   @cdn_url "https://cdn.jsdelivr.net/npm/bitstyles"
 
   def cdn_url do
@@ -14,12 +14,29 @@ defmodule BitstylesPhoenix.Bitstyles do
   """
   def classname(name), do: classname(name, version())
 
-  def classname(class, version) when version > "3.0.1" do
+  def classname(class, version) when version > "4.0.0" do
     IO.warn("Version #{version} of bitstyles is not yet supported")
     class
   end
 
-  def classname(class, version) when version >= "2.0.0", do: class
+  def classname(class, version) when version == "4.0.0", do: class
+
+  def classname(class, version) when version >= "2.0.0" do
+    mapping =
+      case class do
+        "u-overflow-x-auto" -> "u-overflow--x"
+        "u-overflow-y-auto" -> "u-overflow--y"
+        "u-bg-" <> variant -> "u-bg--#{variant}"
+        "u-fg-" <> variant -> "u-fg--#{variant}"
+        "u-font-" <> variant -> "u-font--#{variant}"
+        "u-line-height-" <> variant -> "u-line-height--#{variant}"
+        "u-text-" <> variant -> "u-text--#{variant}"
+        "u-round-" <> variant -> "u-round--#{variant}"
+        _ -> class
+      end
+
+    classname(mapping, "4.0.0")
+  end
 
   def classname(class, version) when version >= "1.5.0" do
     mapping =

--- a/lib/bitstyles_phoenix/component/badge.ex
+++ b/lib/bitstyles_phoenix/component/badge.ex
@@ -25,7 +25,7 @@ defmodule BitstylesPhoenix.Component.Badge do
       ...> </.ui_badge>
       ...> """
       """
-      <span class="a-badge u-h6 u-font--medium a-badge--gray">
+      <span class="a-badge u-h6 u-font-medium a-badge--gray">
         published
       </span>
       """
@@ -39,7 +39,7 @@ defmodule BitstylesPhoenix.Component.Badge do
       ...> </.ui_badge>
       ...> """
       """
-      <span class="a-badge u-h6 u-font--medium a-badge--brand-1">
+      <span class="a-badge u-h6 u-font-medium a-badge--brand-1">
         new
       </span>
       """
@@ -53,7 +53,7 @@ defmodule BitstylesPhoenix.Component.Badge do
       ...> </.ui_badge>
       ...> """
       """
-      <span class="a-badge u-h6 u-font--medium a-badge--brand-2">
+      <span class="a-badge u-h6 u-font-medium a-badge--brand-2">
         recommended
       </span>
       """
@@ -67,7 +67,7 @@ defmodule BitstylesPhoenix.Component.Badge do
       ...> </.ui_badge>
       ...> """
       """
-      <span class="a-badge u-h6 u-font--medium a-badge--danger">
+      <span class="a-badge u-h6 u-font-medium a-badge--danger">
         deleted
       </span>
       """
@@ -81,7 +81,7 @@ defmodule BitstylesPhoenix.Component.Badge do
       ...> </.ui_badge>
       ...> """
       """
-      <span class="a-badge u-h6 u-font--medium a-badge--gray extra-class" data-foo="bar">
+      <span class="a-badge u-h6 u-font-medium a-badge--gray extra-class" data-foo="bar">
         published
       </span>
       """
@@ -92,7 +92,7 @@ defmodule BitstylesPhoenix.Component.Badge do
 
     class =
       classnames([
-        "a-badge u-h6 u-font--medium a-badge--#{variant}",
+        "a-badge u-h6 u-font-medium a-badge--#{variant}",
         assigns[:class]
       ])
 

--- a/lib/bitstyles_phoenix/component/breadcrumbs.ex
+++ b/lib/bitstyles_phoenix/component/breadcrumbs.ex
@@ -44,21 +44,21 @@ defmodule BitstylesPhoenix.Component.Breadcrumbs do
           <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
             <li class="u-margin-xs-right u-flex u-items-center">
               Foo
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
             </li>
             <li class="u-margin-xs-right u-flex u-items-center">
               Bar
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
             </li>
             <li class="u-margin-xs-right u-flex u-items-center">
               Baz
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
@@ -88,21 +88,21 @@ defmodule BitstylesPhoenix.Component.Breadcrumbs do
           <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center">
             <li class="u-margin-xs-right u-flex u-items-center">
               Foo
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
             </li>
             <li class="u-margin-xs-right u-flex u-items-center">
               Bar
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
             </li>
             <li class="u-margin-xs-right u-flex u-items-center">
               Baz
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
@@ -125,32 +125,32 @@ defmodule BitstylesPhoenix.Component.Breadcrumbs do
     '''
         iex> assigns = %{}
         ...> render ~H"""
-        ...> <.ui_breadcrumbs class="u-fg--warning" data-foo="bar">
-        ...>   <:item class="u-fg--brand-2" data-baz="foo">Foo</:item>
+        ...> <.ui_breadcrumbs class="u-fg-warning" data-foo="bar">
+        ...>   <:item class="u-fg-brand-2" data-baz="foo">Foo</:item>
         ...>   <:item>Bar</:item>
         ...>   <:item>Baz</:item>
         ...> </.ui_breadcrumbs>
         ...> """
         """
         <nav aria-label="breadcrumbs" data-foo="bar">
-          <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center u-fg--warning">
-            <li class="u-margin-xs-right u-flex u-items-center u-fg--brand-2" data-baz="foo">
+          <ol class="u-h6 a-list-reset u-flex u-flex-wrap u-items-center u-fg-warning">
+            <li class="u-margin-xs-right u-flex u-items-center u-fg-brand-2" data-baz="foo">
               Foo
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
             </li>
             <li class="u-margin-xs-right u-flex u-items-center">
               Bar
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
             </li>
             <li class="u-margin-xs-right u-flex u-items-center">
               Baz
-              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg--gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
+              <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="a-icon a-icon--m u-fg-gray-30 u-margin-xs-left" focusable="false" height="16" width="16">
                 <use xlink:href="#icon-caret-right">
                 </use>
               </svg>
@@ -182,7 +182,7 @@ defmodule BitstylesPhoenix.Component.Breadcrumbs do
               {assigns[:item] && assigns_to_attributes(item, [:class]) || []}
             >
               <%= if assigns[:item], do: render_slot(item), else: item %>
-              <.ui_icon name="caret-right" size="m" class="u-fg--gray-30 u-margin-xs-left" {@icon_extra} />
+              <.ui_icon name="caret-right" size="m" class="u-fg-gray-30 u-margin-xs-left" {@icon_extra} />
             </li>
           <% end %>
         </ol>

--- a/lib/bitstyles_phoenix/component/description_list.ex
+++ b/lib/bitstyles_phoenix/component/description_list.ex
@@ -17,7 +17,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
         ...> """
         """
         <dl class="a-dl">
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
               Length
             </dt>
@@ -25,7 +25,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
               8
             </dd>
           </div>
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
               Inserted at
             </dt>
@@ -59,7 +59,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
         ...> """
         """
         <dl class="a-dl extra" data-foo="baz">
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-fg--brand-2">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline u-fg--brand-2">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
               Length
             </dt>
@@ -67,7 +67,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
               8
             </dd>
           </div>
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s u-fg--brand-1" data-foo="bar">
               Some
             </dt>
@@ -75,7 +75,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
               Tag
             </dd>
           </div>
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
             <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
               <pre>
                 Tag
@@ -132,7 +132,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
     assigns = assign(assigns, extra: extra)
 
     ~H"""
-      <div class={classnames(["a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m", assigns[:class]])} {@extra}>
+      <div class={classnames(["a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline u-items-baseline", assigns[:class]])} {@extra}>
         <%= if assigns[:label] do %>
           <.ui_dt><%= @label %></.ui_dt>
           <.ui_dd><%= assigns[:value] || render_slot(@inner_block) %></.ui_dd>

--- a/lib/bitstyles_phoenix/component/description_list.ex
+++ b/lib/bitstyles_phoenix/component/description_list.ex
@@ -18,7 +18,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
         """
         <dl class="a-dl">
           <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">
               Length
             </dt>
             <dd class="u-col-span-2">
@@ -26,7 +26,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
             </dd>
           </div>
           <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">
               Inserted at
             </dt>
             <dd class="u-col-span-2">
@@ -46,10 +46,10 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
         iex> assigns = %{}
         ...> render ~H"""
         ...> <.ui_dl class="extra" data-foo="baz">
-        ...>   <.ui_dl_item label="Length" class="u-fg--brand-2">8</.ui_dl_item>
+        ...>   <.ui_dl_item label="Length" class="u-fg-brand-2">8</.ui_dl_item>
         ...>   <.ui_dl_item>
-        ...>     <.ui_dt class="u-fg--brand-1" data-foo="bar">Some</.ui_dt>
-        ...>     <.ui_dd class="u-fg--brand-1" data-foo="bar">Tag</.ui_dd>
+        ...>     <.ui_dt class="u-fg-brand-1" data-foo="bar">Some</.ui_dt>
+        ...>     <.ui_dd class="u-fg-brand-1" data-foo="bar">Tag</.ui_dd>
         ...>   </.ui_dl_item>
         ...>   <.ui_dl_item>
         ...>     <.ui_dt><pre>Tag</pre></.ui_dt>
@@ -59,8 +59,8 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
         ...> """
         """
         <dl class="a-dl extra" data-foo="baz">
-          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline u-fg--brand-2">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
+          <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline u-fg-brand-2">
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">
               Length
             </dt>
             <dd class="u-col-span-2">
@@ -68,15 +68,15 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
             </dd>
           </div>
           <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s u-fg--brand-1" data-foo="bar">
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s u-fg-brand-1" data-foo="bar">
               Some
             </dt>
-            <dd class="u-col-span-2 u-fg--brand-1" data-foo="bar">
+            <dd class="u-col-span-2 u-fg-brand-1" data-foo="bar">
               Tag
             </dd>
           </div>
           <div class="a-dl__item u-grid@m u-grid-cols-3 u-gap-m u-padding-m-y u-padding-m@m u-items-baseline">
-            <dt class="u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s">
+            <dt class="u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s">
               <pre>
                 Tag
               </pre>
@@ -158,7 +158,7 @@ defmodule BitstylesPhoenix.Component.DescriptionList do
     assigns = assign(assigns, extra: extra)
 
     ~H"""
-    <dt class={classnames(["u-font--medium u-h6 u-fg--gray-50 u-margin-xs-bottom@s", assigns[:class]])} {@extra}>
+    <dt class={classnames(["u-font-medium u-h6 u-fg-gray-50 u-margin-xs-bottom@s", assigns[:class]])} {@extra}>
       <%= render_slot(@inner_block) %>
     </dt>
     """

--- a/lib/bitstyles_phoenix/component/dropdown.ex
+++ b/lib/bitstyles_phoenix/component/dropdown.ex
@@ -75,7 +75,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
               </use>
             </svg>
           </button>
-          <ul class="a-dropdown u-overflow--y a-list-reset u-margin-s-top">
+          <ul class="a-dropdown u-overflow-y-auto a-list-reset u-margin-s-top">
             <li>
               <a href="#" class="a-button a-button--menu u-h6">
                 Option 1
@@ -133,7 +133,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
                 </use>
               </svg>
             </button>
-            <ul class="a-dropdown u-overflow--y a-list-reset a-dropdown--top u-margin-s-bottom">
+            <ul class="a-dropdown u-overflow-y-auto a-list-reset a-dropdown--top u-margin-s-bottom">
               <li>
                 <a href="#" class="a-button a-button--menu u-h6">
                   Option 1
@@ -186,7 +186,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
               </use>
             </svg>
           </button>
-          <ul class="a-dropdown u-overflow--y a-list-reset a-dropdown--right u-margin-s-top">
+          <ul class="a-dropdown u-overflow-y-auto a-list-reset a-dropdown--right u-margin-s-top">
             <li>
               <a href="#" class="a-button a-button--menu">
                 Option 1
@@ -245,7 +245,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
                 </use>
               </svg>
             </button>
-            <ul class="a-dropdown u-overflow--y a-list-reset a-dropdown--top a-dropdown--right u-margin-s-bottom">
+            <ul class="a-dropdown u-overflow-y-auto a-list-reset a-dropdown--top a-dropdown--right u-margin-s-bottom">
               <li>
                 <a href="#" class="a-button a-button--menu u-h6">
                   Option 1
@@ -293,7 +293,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
           <button type="button" class="a-button a-button--ui foo">
             Custom button content
           </button>
-          <ul class="a-dropdown u-overflow--y a-list-reset u-margin-s-top">
+          <ul class="a-dropdown u-overflow-y-auto a-list-reset u-margin-s-top">
             <li>
               <a href="#" class="a-button a-button--menu u-h6">
                 Option 1
@@ -345,7 +345,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
                 </use>
               </svg>
             </button>
-            <ul class="a-dropdown u-overflow--y a-list-reset a-dropdown--full-width u-margin-s-top" id="dropdown-1" style="display: none">
+            <ul class="a-dropdown u-overflow-y-auto a-list-reset a-dropdown--full-width u-margin-s-top" id="dropdown-1" style="display: none">
               <li>
                 <a href="#" class="a-button a-button--menu foo">
                   Option 1
@@ -458,7 +458,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
 
   defp maybe_put_icon(button_extra, _, _), do: button_extra
 
-  @menu_classes ~w(a-dropdown u-overflow--y a-list-reset)
+  @menu_classes ~w(a-dropdown u-overflow-y-auto a-list-reset)
   defp menu_class(variant, class) do
     classnames(@menu_classes ++ variant_classes(variant) ++ [margin(variant), class])
   end

--- a/lib/bitstyles_phoenix/component/dropdown.ex
+++ b/lib/bitstyles_phoenix/component/dropdown.ex
@@ -410,7 +410,7 @@ defmodule BitstylesPhoenix.Component.Dropdown do
         button_label: button[:label],
         button_extra: button_extra,
         menu_extra: menu_extra,
-        menu_class: menu_class(assigns[:variant], menu && menu[:class])
+        menu_class: menu_class(assigns[:variant], menu[:class])
       )
 
     ~H"""

--- a/lib/bitstyles_phoenix/component/error.ex
+++ b/lib/bitstyles_phoenix/component/error.ex
@@ -29,7 +29,7 @@ defmodule BitstylesPhoenix.Component.Error do
       ...> <.ui_errors form={@form} field={:single} />
       ...> """
       """
-      <span class="u-fg--warning" phx-feedback-for="user[single]">
+      <span class="u-fg-warning" phx-feedback-for="user[single]">
         is too short
       </span>
       """
@@ -43,12 +43,12 @@ defmodule BitstylesPhoenix.Component.Error do
       """
       <ul class="u-padding-xl-left">
         <li>
-          <span class="u-fg--warning" phx-feedback-for="user[multiple]">
+          <span class="u-fg-warning" phx-feedback-for="user[multiple]">
             is simply bad
           </span>
         </li>
         <li>
-          <span class="u-fg--warning" phx-feedback-for="user[multiple]">
+          <span class="u-fg-warning" phx-feedback-for="user[multiple]">
             not fun
           </span>
         </li>
@@ -112,7 +112,7 @@ defmodule BitstylesPhoenix.Component.Error do
       ...> <.ui_error error={{"Foo error", []}} />
       ...> """
       """
-      <span class="u-fg--warning">
+      <span class="u-fg-warning">
         Foo error
       </span>
       """
@@ -124,7 +124,7 @@ defmodule BitstylesPhoenix.Component.Error do
       ...> <.ui_error error={@error} phx-feedback-for="foo" class="bar" />
       ...> """
       """
-      <span class="u-fg--warning bar" phx-feedback-for="foo">
+      <span class="u-fg-warning bar" phx-feedback-for="foo">
         Foo error
       </span>
       """
@@ -132,7 +132,7 @@ defmodule BitstylesPhoenix.Component.Error do
 
   def ui_error(assigns) do
     extra = assigns_to_attributes(assigns, [:class, :error, :field, :form])
-    class = classnames(["u-fg--warning", assigns[:class]])
+    class = classnames(["u-fg-warning", assigns[:class]])
     assigns = assign(assigns, class: class, extra: extra)
 
     ~H"""

--- a/lib/bitstyles_phoenix/component/flash.ex
+++ b/lib/bitstyles_phoenix/component/flash.ex
@@ -37,7 +37,7 @@ defmodule BitstylesPhoenix.Component.Flash do
         ...> """)
         """
         <div aria-live="polite" class="u-padding-l-y a-flash a-flash--brand-1">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             Something you may be interested to hear
           </div>
         </div>
@@ -57,7 +57,7 @@ defmodule BitstylesPhoenix.Component.Flash do
         ...> """)
         """
         <div aria-live="polite" class="u-padding-l-y a-flash a-flash--positive">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             Saved successfully
           </div>
         </div>
@@ -77,7 +77,7 @@ defmodule BitstylesPhoenix.Component.Flash do
         ...> """)
         """
         <div aria-live="polite" class="u-padding-l-y a-flash a-flash--warning">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             Saved with errors
           </div>
         </div>
@@ -97,7 +97,7 @@ defmodule BitstylesPhoenix.Component.Flash do
         ...> """)
         """
         <div aria-live="polite" class="u-padding-l-y a-flash a-flash--danger">
-          <div class="a-content u-flex u-items-center u-font--medium">
+          <div class="a-content u-flex u-items-center u-font-medium">
             Saving failed
           </div>
         </div>
@@ -117,7 +117,7 @@ defmodule BitstylesPhoenix.Component.Flash do
         ...> """)
         """
         <div aria-live="polite" class="u-padding-l-y a-flash a-flash--danger">
-          <div class="a-content a-content--full u-flex u-items-center u-font--medium">
+          <div class="a-content a-content--full u-flex u-items-center u-font-medium">
             Saving failed
           </div>
         </div>
@@ -137,7 +137,7 @@ defmodule BitstylesPhoenix.Component.Flash do
         ...> """)
         """
         <div aria-live="polite" class="u-padding-l-y a-flash a-flash--brand-1 extra-class" data-foo="bar">
-          <div class="a-content u-flex u-items-center u-font--medium extra-inner-class">
+          <div class="a-content u-flex u-items-center u-font-medium extra-inner-class">
             Saving failed
           </div>
         </div>
@@ -161,7 +161,7 @@ defmodule BitstylesPhoenix.Component.Flash do
         assigns[:class]
       ])
 
-    content_class = classnames(["u-flex u-items-center u-font--medium", assigns[:content_class]])
+    content_class = classnames(["u-flex u-items-center u-font-medium", assigns[:content_class]])
 
     extra = assigns_to_attributes(assigns, [:class, :content_class, :variant])
 

--- a/lib/bitstyles_phoenix/component/form.ex
+++ b/lib/bitstyles_phoenix/component/form.ex
@@ -89,7 +89,7 @@ defmodule BitstylesPhoenix.Component.Form do
         Name
       </label>
       <input id="user_name" maxlength="255" name="user[name]" type="text"/>
-      <span class="u-fg--warning" phx-feedback-for="user[name]">
+      <span class="u-fg-warning" phx-feedback-for="user[name]">
         is too short
       </span>
       """
@@ -107,12 +107,12 @@ defmodule BitstylesPhoenix.Component.Form do
       <input id="user_email" maxlength="255" name="user[email]" type="text"/>
       <ul class=\"u-padding-xl-left\">
         <li>
-          <span class=\"u-fg--warning\" phx-feedback-for=\"user[email]\">
+          <span class=\"u-fg-warning\" phx-feedback-for=\"user[email]\">
             is invalid
           </span>
         </li>
         <li>
-          <span class=\"u-fg--warning\" phx-feedback-for=\"user[email]\">
+          <span class=\"u-fg-warning\" phx-feedback-for=\"user[email]\">
             must end with @bitcrowd.net
           </span>
         </li>
@@ -351,7 +351,7 @@ defmodule BitstylesPhoenix.Component.Form do
       </label>
       <textarea id="user_name" name="user[name]">
       </textarea>
-      <span class="u-fg--warning" phx-feedback-for="user[name]">
+      <span class="u-fg-warning" phx-feedback-for="user[name]">
         is too short
       </span>
       """
@@ -487,7 +487,7 @@ defmodule BitstylesPhoenix.Component.Form do
       </label>
       Custom content
       <input type="text" whatever="foo"/>
-      <span class="u-fg--warning" phx-feedback-for="user[name]">
+      <span class="u-fg-warning" phx-feedback-for="user[name]">
         is too short
       </span>
       """

--- a/lib/bitstyles_phoenix/component/heading.ex
+++ b/lib/bitstyles_phoenix/component/heading.ex
@@ -76,7 +76,7 @@ defmodule BitstylesPhoenix.Component.Heading do
               Title
             </h1>
             <div class="u-flex-shrink-0 u-margin-m-bottom">
-              <span class="a-badge u-h6 u-font--medium a-badge--gray">
+              <span class="a-badge u-h6 u-font-medium a-badge--gray">
                 Published
               </span>
             </div>
@@ -221,7 +221,7 @@ defmodule BitstylesPhoenix.Component.Heading do
             <h3 class="u-margin-0 u-margin-m-right u-break-text">
               Section title
             </h3>
-            <span class="a-badge u-h6 u-font--medium a-badge--gray">
+            <span class="a-badge u-h6 u-font-medium a-badge--gray">
               Published
             </span>
           </div>
@@ -263,7 +263,7 @@ defmodule BitstylesPhoenix.Component.Heading do
       <div class={@class} {@extra}>
         <div class="u-flex u-items-center">
           <%= Phoenix.HTML.Tag.content_tag @tag, class: "u-margin-0 u-margin-m-right u-break-text" do %>
-            <%= render_slot(@inner_block) %> 
+            <%= render_slot(@inner_block) %>
           <% end %>
           <%= assigns[:title_extra] && render_slot(@title_extra) %>
         </div>

--- a/lib/bitstyles_phoenix/component/sidebar.ex
+++ b/lib/bitstyles_phoenix/component/sidebar.ex
@@ -41,12 +41,12 @@ defmodule BitstylesPhoenix.Component.Sidebar do
         <div class="u-flex u-height-100vh">
           <header role="banner" class="u-flex">
             <nav class="u-flex">
-              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg--gray-80 u-fg--gray-30">
+              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg-gray-80 u-fg-gray-30">
                 Large header
                 <div class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-flex u-flex-col u-border-gray-70-bottom u-margin-xs-bottom">
                   Menu
                 </div>
-                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
                   <li class="u-margin-xs-bottom u-flex">
                     <a href="#" class="a-button a-button--nav u-flex-grow-1">
                       Menu item #1
@@ -68,7 +68,7 @@ defmodule BitstylesPhoenix.Component.Sidebar do
                         Jane Dobermann
                       </span>
                     </button>
-                    <ul class="a-dropdown u-overflow--y a-list-reset a-dropdown--top a-dropdown--full-width u-margin-s-bottom">
+                    <ul class="a-dropdown u-overflow-y-auto a-list-reset a-dropdown--top a-dropdown--full-width u-margin-s-bottom">
                       <li>
                         <a href="#" class="a-button a-button--menu">
                           Logout
@@ -78,12 +78,12 @@ defmodule BitstylesPhoenix.Component.Sidebar do
                   </div>
                 </div>
               </div>
-              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg--gray-80 u-fg--gray-30">
+              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg-gray-80 u-fg-gray-30">
                 Small header
                 <div class="u-flex-shrink-0 u-padding-xs-y u-margin-xs-left u-margin-xs-right u-flex u-flex-col u-border-gray-70-bottom u-margin-xs-bottom">
                   Menu
                 </div>
-                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
+                <ul class="u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left">
                   <li class="u-margin-xs-bottom u-flex">
                     <a href="#" class="a-button a-button--nav u-flex-grow-1">
                       Menu item #1
@@ -105,7 +105,7 @@ defmodule BitstylesPhoenix.Component.Sidebar do
                         Jane Dobermann
                       </span>
                     </button>
-                    <ul class="a-dropdown u-overflow--y a-list-reset a-dropdown--top a-dropdown--full-width u-margin-s-bottom">
+                    <ul class="a-dropdown u-overflow-y-auto a-list-reset a-dropdown--top a-dropdown--full-width u-margin-s-bottom">
                       <li>
                         <a href="#" class="a-button a-button--menu">
                           Logout
@@ -117,7 +117,7 @@ defmodule BitstylesPhoenix.Component.Sidebar do
               </div>
             </nav>
           </header>
-          <main class="u-flex-grow-1 u-overflow--y">
+          <main class="u-flex-grow-1 u-overflow-y-auto">
             Main Content
           </main>
         </div>
@@ -203,13 +203,13 @@ defmodule BitstylesPhoenix.Component.Sidebar do
         <div class="u-flex u-height-100vh">
           <header role="banner" class="u-flex">
             <nav class="u-flex">
-              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg--gray-80 u-fg--gray-30">
+              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg-gray-80 u-fg-gray-30">
                 Large header
                 <div>
                   Sidebar
                 </div>
               </div>
-              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg--gray-80 u-fg--gray-30">
+              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg-gray-80 u-fg-gray-30">
                 Small header
                 <div>
                   Sidebar
@@ -217,7 +217,7 @@ defmodule BitstylesPhoenix.Component.Sidebar do
               </div>
             </nav>
           </header>
-          <main class="u-flex-grow-1 u-overflow--y">
+          <main class="u-flex-grow-1 u-overflow-y-auto">
             Main Content
           </main>
         </div>
@@ -241,13 +241,13 @@ defmodule BitstylesPhoenix.Component.Sidebar do
         <div class="u-flex u-height-100vh">
           <header role="banner" class="u-flex">
             <nav class="u-flex">
-              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg--gray-80 u-fg--gray-30">
+              <div class="u-hidden o-sidebar--large u-flex-shrink-0 u-padding-m-top u-flex@l u-flex-col u-bg-gray-80 u-fg-gray-30">
               </div>
-              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg--gray-80 u-fg--gray-30">
+              <div class="o-sidebar--small u-flex u-flex-col u-hidden@l u-bg-gray-80 u-fg-gray-30">
               </div>
             </nav>
           </header>
-          <main class="u-flex-grow-1 u-overflow--y">
+          <main class="u-flex-grow-1 u-overflow-y-auto">
             Main Content
           </main>
         </div>
@@ -303,7 +303,7 @@ defmodule BitstylesPhoenix.Component.Sidebar do
         large_extra: large_extra,
         small_extra: small_extra,
         main_extra: main_extra,
-        main_class: classnames(["u-flex-grow-1 u-overflow--y", main[:class]]),
+        main_class: classnames(["u-flex-grow-1 u-overflow-y-auto", main[:class]]),
         large_class: sidebar_classnames(large_sidebar, sidebar, @large_classes),
         small_class: sidebar_classnames(small_sidebar, sidebar, @small_classes)
       )
@@ -336,8 +336,8 @@ defmodule BitstylesPhoenix.Component.Sidebar do
 
     classnames([
       default_classes,
-      {"u-bg--#{bg}", !!bg},
-      {"u-fg--#{fg}", !!fg},
+      {"u-bg-#{bg}", !!bg},
+      {"u-fg-#{fg}", !!fg},
       sidebar[:class],
       sidebar_layout[:class]
     ])
@@ -354,7 +354,7 @@ defmodule BitstylesPhoenix.Component.Sidebar do
 
   You can add items `ui_sidebar_nav_item/1` to add items to the navigation.
   """
-  @sidebar_nav_classes "u-flex-grow-1 u-flex-shrink-1 u-overflow--y a-list-reset u-flex " <>
+  @sidebar_nav_classes "u-flex-grow-1 u-flex-shrink-1 u-overflow-y-auto a-list-reset u-flex " <>
                          "u-flex-col u-items-stretch u-padding-xs-right u-padding-xs-left"
   def ui_sidebar_nav(assigns) do
     extra = assigns_to_attributes(assigns, [:class])

--- a/test/bitstyles_phoenix/bitstyles_test.exs
+++ b/test/bitstyles_phoenix/bitstyles_test.exs
@@ -16,22 +16,22 @@ defmodule BitstylesPhoenix.BitstylesTest do
     end
 
     test "version 4.1.0" do
-      assert classname("u-flex", "4.0.0") == "u-flex"
-      assert classname("u-border-radius-0", "4.0.0") == "u-round-0"
-      assert classname("u-overflow-x-auto", "4.0.0") == "u-overflow-x-auto"
-      assert classname("u-overflow-y-auto", "4.0.0") == "u-overflow-y-auto"
-      assert classname("u-bg-gray-80", "4.0.0") == "u-bg-gray-80"
-      assert classname("u-fg-warning", "4.0.0") == "u-fg-warning"
-      assert classname("u-font-medium", "4.0.0") == "u-font-medium"
-      assert classname("u-line-height-min", "4.0.0") == "u-line-height-min"
-      assert classname("u-text-right", "4.0.0") == "u-text-right"
-      assert classname("u-flex-shrink-0", "4.0.0") == "u-flex-shrink-0"
-      assert classname("u-flex-grow-1", "4.0.0") == "u-flex-grow-1"
-      assert classname("u-flex-wrap", "4.0.0") == "u-flex-wrap"
-      assert classname("u-flex-col", "4.0.0") == "u-flex-col"
-      assert classname("u-grid-cols-3", "4.0.0") == "u-grid-cols-3"
-      assert classname("u-col-span-3", "4.0.0") == "u-col-span-3"
-      assert classname("u-col-start-1", "4.0.0") == "u-col-start-1"
+      assert classname("u-flex", "4.1.0") == "u-flex"
+      assert classname("u-border-radius-0", "4.1.0") == "u-round-0"
+      assert classname("u-overflow-x-auto", "4.1.0") == "u-overflow-x-auto"
+      assert classname("u-overflow-y-auto", "4.1.0") == "u-overflow-y-auto"
+      assert classname("u-bg-gray-80", "4.1.0") == "u-bg-gray-80"
+      assert classname("u-fg-warning", "4.1.0") == "u-fg-warning"
+      assert classname("u-font-medium", "4.1.0") == "u-font-medium"
+      assert classname("u-line-height-min", "4.1.0") == "u-line-height-min"
+      assert classname("u-text-right", "4.1.0") == "u-text-right"
+      assert classname("u-flex-shrink-0", "4.1.0") == "u-flex-shrink-0"
+      assert classname("u-flex-grow-1", "4.1.0") == "u-flex-grow-1"
+      assert classname("u-flex-wrap", "4.1.0") == "u-flex-wrap"
+      assert classname("u-flex-col", "4.1.0") == "u-flex-col"
+      assert classname("u-grid-cols-3", "4.1.0") == "u-grid-cols-3"
+      assert classname("u-col-span-3", "4.1.0") == "u-col-span-3"
+      assert classname("u-col-start-1", "4.1.0") == "u-col-start-1"
     end
 
     test "version 4.0.0" do

--- a/test/bitstyles_phoenix/bitstyles_test.exs
+++ b/test/bitstyles_phoenix/bitstyles_test.exs
@@ -11,8 +11,13 @@ defmodule BitstylesPhoenix.BitstylesTest do
              )
     end
 
-    test "version 4.0.0" do
+    test "version 4.2.0" do
+      assert classname("u-border-radius-0", "4.2.0") == "u-border-radius-0"
+    end
+
+    test "version 4.1.0" do
       assert classname("u-flex", "4.0.0") == "u-flex"
+      assert classname("u-border-radius-0", "4.0.0") == "u-round-0"
       assert classname("u-overflow-x-auto", "4.0.0") == "u-overflow-x-auto"
       assert classname("u-overflow-y-auto", "4.0.0") == "u-overflow-y-auto"
       assert classname("u-bg-gray-80", "4.0.0") == "u-bg-gray-80"
@@ -20,7 +25,25 @@ defmodule BitstylesPhoenix.BitstylesTest do
       assert classname("u-font-medium", "4.0.0") == "u-font-medium"
       assert classname("u-line-height-min", "4.0.0") == "u-line-height-min"
       assert classname("u-text-right", "4.0.0") == "u-text-right"
-      assert classname("u-round-0-tr", "4.0.0") == "u-round-0-tr"
+      assert classname("u-flex-shrink-0", "4.0.0") == "u-flex-shrink-0"
+      assert classname("u-flex-grow-1", "4.0.0") == "u-flex-grow-1"
+      assert classname("u-flex-wrap", "4.0.0") == "u-flex-wrap"
+      assert classname("u-flex-col", "4.0.0") == "u-flex-col"
+      assert classname("u-grid-cols-3", "4.0.0") == "u-grid-cols-3"
+      assert classname("u-col-span-3", "4.0.0") == "u-col-span-3"
+      assert classname("u-col-start-1", "4.0.0") == "u-col-start-1"
+    end
+
+    test "version 4.0.0" do
+      assert classname("u-flex", "4.0.0") == "u-flex"
+      assert classname("u-border-radius-0", "4.0.0") == "u-round-0"
+      assert classname("u-overflow-x-auto", "4.0.0") == "u-overflow-x-auto"
+      assert classname("u-overflow-y-auto", "4.0.0") == "u-overflow-y-auto"
+      assert classname("u-bg-gray-80", "4.0.0") == "u-bg-gray-80"
+      assert classname("u-fg-warning", "4.0.0") == "u-fg-warning"
+      assert classname("u-font-medium", "4.0.0") == "u-font-medium"
+      assert classname("u-line-height-min", "4.0.0") == "u-line-height-min"
+      assert classname("u-text-right", "4.0.0") == "u-text-right"
       assert classname("u-flex-shrink-0", "4.0.0") == "u-flex-shrink-0"
       assert classname("u-flex-grow-1", "4.0.0") == "u-flex-grow-1"
       assert classname("u-flex-wrap", "4.0.0") == "u-flex-wrap"
@@ -39,7 +62,7 @@ defmodule BitstylesPhoenix.BitstylesTest do
       assert classname("u-font-medium", "3.0.0") == "u-font--medium"
       assert classname("u-line-height-min", "3.0.0") == "u-line-height--min"
       assert classname("u-text-right", "3.0.0") == "u-text--right"
-      assert classname("u-round-0-tr", "3.0.0") == "u-round--0-tr"
+      assert classname("u-border-radius-0-tr", "3.0.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "3.0.0") == "u-flex-shrink-0"
       assert classname("u-flex-grow-1", "3.0.0") == "u-flex-grow-1"
       assert classname("u-flex-wrap", "3.0.0") == "u-flex-wrap"
@@ -58,7 +81,7 @@ defmodule BitstylesPhoenix.BitstylesTest do
       assert classname("u-font-medium", "2.0.0") == "u-font--medium"
       assert classname("u-line-height-min", "2.0.0") == "u-line-height--min"
       assert classname("u-text-right", "2.0.0") == "u-text--right"
-      assert classname("u-round-0-tr", "2.0.0") == "u-round--0-tr"
+      assert classname("u-border-radius-0-tr", "2.0.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "2.0.0") == "u-flex-shrink-0"
       assert classname("u-flex-grow-1", "2.0.0") == "u-flex-grow-1"
       assert classname("u-flex-wrap", "2.0.0") == "u-flex-wrap"
@@ -77,7 +100,7 @@ defmodule BitstylesPhoenix.BitstylesTest do
       assert classname("u-font-medium", "1.5.0") == "u-font--medium"
       assert classname("u-line-height-min", "1.5.0") == "u-line-height--min"
       assert classname("u-text-right", "1.5.0") == "u-text--right"
-      assert classname("u-round-0-tr", "1.5.0") == "u-round--0-tr"
+      assert classname("u-border-radius-0-tr", "1.5.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "1.5.0") == "u-flex__shrink-0"
       assert classname("u-flex-grow-1", "1.5.0") == "u-flex__grow-1"
       assert classname("u-flex-wrap", "1.5.0") == "u-flex--wrap"
@@ -96,7 +119,7 @@ defmodule BitstylesPhoenix.BitstylesTest do
       assert classname("u-font-medium", "1.3.0") == "u-font--medium"
       assert classname("u-line-height-min", "1.3.0") == "u-line-height--min"
       assert classname("u-text-right", "1.3.0") == "u-text--right"
-      assert classname("u-round-0-tr", "1.3.0") == "u-round--0-tr"
+      assert classname("u-border-radius-0-tr", "1.3.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "1.3.0") == "u-flex__shrink-0"
       assert classname("u-flex-grow-1", "1.3.0") == "u-flex__grow-1"
       assert classname("u-flex-wrap", "1.3.0") == "u-flex--wrap"

--- a/test/bitstyles_phoenix/bitstyles_test.exs
+++ b/test/bitstyles_phoenix/bitstyles_test.exs
@@ -4,15 +4,42 @@ defmodule BitstylesPhoenix.BitstylesTest do
   import ExUnit.CaptureIO
 
   describe "classname/2" do
-    test "version 4.0.0" do
+    test "version 5.0.0" do
       assert Regex.match?(
-               ~r/4.0.0 of bitstyles is not yet supported/,
-               capture_io(:stderr, fn -> classname("u-flex", "4.0.0") end)
+               ~r/5.0.0 of bitstyles is not yet supported/,
+               capture_io(:stderr, fn -> classname("u-flex", "5.0.0") end)
              )
+    end
+
+    test "version 4.0.0" do
+      assert classname("u-flex", "4.0.0") == "u-flex"
+      assert classname("u-overflow-x-auto", "4.0.0") == "u-overflow-x-auto"
+      assert classname("u-overflow-y-auto", "4.0.0") == "u-overflow-y-auto"
+      assert classname("u-bg-gray-80", "4.0.0") == "u-bg-gray-80"
+      assert classname("u-fg-warning", "4.0.0") == "u-fg-warning"
+      assert classname("u-font-medium", "4.0.0") == "u-font-medium"
+      assert classname("u-line-height-min", "4.0.0") == "u-line-height-min"
+      assert classname("u-text-right", "4.0.0") == "u-text-right"
+      assert classname("u-round-0-tr", "4.0.0") == "u-round-0-tr"
+      assert classname("u-flex-shrink-0", "4.0.0") == "u-flex-shrink-0"
+      assert classname("u-flex-grow-1", "4.0.0") == "u-flex-grow-1"
+      assert classname("u-flex-wrap", "4.0.0") == "u-flex-wrap"
+      assert classname("u-flex-col", "4.0.0") == "u-flex-col"
+      assert classname("u-grid-cols-3", "4.0.0") == "u-grid-cols-3"
+      assert classname("u-col-span-3", "4.0.0") == "u-col-span-3"
+      assert classname("u-col-start-1", "4.0.0") == "u-col-start-1"
     end
 
     test "version 3.0.0" do
       assert classname("u-flex", "3.0.0") == "u-flex"
+      assert classname("u-overflow-x-auto", "3.0.0") == "u-overflow--x"
+      assert classname("u-overflow-y-auto", "3.0.0") == "u-overflow--y"
+      assert classname("u-bg-gray-80", "3.0.0") == "u-bg--gray-80"
+      assert classname("u-fg-warning", "3.0.0") == "u-fg--warning"
+      assert classname("u-font-medium", "3.0.0") == "u-font--medium"
+      assert classname("u-line-height-min", "3.0.0") == "u-line-height--min"
+      assert classname("u-text-right", "3.0.0") == "u-text--right"
+      assert classname("u-round-0-tr", "3.0.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "3.0.0") == "u-flex-shrink-0"
       assert classname("u-flex-grow-1", "3.0.0") == "u-flex-grow-1"
       assert classname("u-flex-wrap", "3.0.0") == "u-flex-wrap"
@@ -24,6 +51,14 @@ defmodule BitstylesPhoenix.BitstylesTest do
 
     test "version 2.0.0" do
       assert classname("u-flex", "2.0.0") == "u-flex"
+      assert classname("u-overflow-x-auto", "2.0.0") == "u-overflow--x"
+      assert classname("u-overflow-y-auto", "2.0.0") == "u-overflow--y"
+      assert classname("u-bg-gray-80", "2.0.0") == "u-bg--gray-80"
+      assert classname("u-fg-warning", "2.0.0") == "u-fg--warning"
+      assert classname("u-font-medium", "2.0.0") == "u-font--medium"
+      assert classname("u-line-height-min", "2.0.0") == "u-line-height--min"
+      assert classname("u-text-right", "2.0.0") == "u-text--right"
+      assert classname("u-round-0-tr", "2.0.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "2.0.0") == "u-flex-shrink-0"
       assert classname("u-flex-grow-1", "2.0.0") == "u-flex-grow-1"
       assert classname("u-flex-wrap", "2.0.0") == "u-flex-wrap"
@@ -35,6 +70,14 @@ defmodule BitstylesPhoenix.BitstylesTest do
 
     test "version 1.5.0" do
       assert classname("u-flex", "1.5.0") == "u-flex"
+      assert classname("u-overflow-x-auto", "1.5.0") == "u-overflow--x"
+      assert classname("u-overflow-y-auto", "1.5.0") == "u-overflow--y"
+      assert classname("u-bg-gray-80", "1.5.0") == "u-bg--gray-80"
+      assert classname("u-fg-warning", "1.5.0") == "u-fg--warning"
+      assert classname("u-font-medium", "1.5.0") == "u-font--medium"
+      assert classname("u-line-height-min", "1.5.0") == "u-line-height--min"
+      assert classname("u-text-right", "1.5.0") == "u-text--right"
+      assert classname("u-round-0-tr", "1.5.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "1.5.0") == "u-flex__shrink-0"
       assert classname("u-flex-grow-1", "1.5.0") == "u-flex__grow-1"
       assert classname("u-flex-wrap", "1.5.0") == "u-flex--wrap"
@@ -46,6 +89,14 @@ defmodule BitstylesPhoenix.BitstylesTest do
 
     test "version 1.3.0" do
       assert classname("u-flex", "1.3.0") == "u-flex"
+      assert classname("u-overflow-x-auto", "1.3.0") == "u-overflow--x"
+      assert classname("u-overflow-y-auto", "1.3.0") == "u-overflow--y"
+      assert classname("u-bg-gray-80", "1.3.0") == "u-bg--gray-80"
+      assert classname("u-fg-warning", "1.3.0") == "u-fg--warning"
+      assert classname("u-font-medium", "1.3.0") == "u-font--medium"
+      assert classname("u-line-height-min", "1.3.0") == "u-line-height--min"
+      assert classname("u-text-right", "1.3.0") == "u-text--right"
+      assert classname("u-round-0-tr", "1.3.0") == "u-round--0-tr"
       assert classname("u-flex-shrink-0", "1.3.0") == "u-flex__shrink-0"
       assert classname("u-flex-grow-1", "1.3.0") == "u-flex__grow-1"
       assert classname("u-flex-wrap", "1.3.0") == "u-flex--wrap"


### PR DESCRIPTION
This PR updates to bitstyles version `4.3.0` and adds support for lower versions.

Bitstyles changelog:
https://github.com/bitcrowd/bitstyles/blob/main/CHANGELOG.md#430---2022-05-25