### PR TITLE
Fix checked & unchecked values

### DIFF
--- a/lib/bitstyles_phoenix/component/form.ex
+++ b/lib/bitstyles_phoenix/component/form.ex
@@ -354,7 +354,7 @@ defmodule BitstylesPhoenix.Component.Form do
   )
 
   story(
-    "Checkbox with label class",
+    "Checkbox with custom value",
     """
         iex> assigns=%{form: form()}
         ...> render ~H\"""


### PR DESCRIPTION
We seem to have broken `checked_vlue` and `unchecked_value` for checkboxes in some update. Let's bring it back. 